### PR TITLE
fix: improve error handling and minor cleanups

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,4 +23,4 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build --if-present
-      - run: npm publish
+      - run: npm publish --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist/
 .claude/settings.local.json
 
 .context
-.claude/settings.local.json

--- a/components/DmnDrd.vue
+++ b/components/DmnDrd.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <p v-if="loading">Loading DMN diagram...</p>
-    <p v-if="error" class="text-red-500">{{ error }}</p>
-    <div v-if="svg" v-html="svg"></div>
+    <p v-else-if="error" class="text-red-500">{{ error }}</p>
+    <div v-else-if="svg" v-html="svg"></div>
   </div>
 </template>
 
@@ -94,8 +94,8 @@ async function loadAndRenderDrd(path: string): Promise<void> {
 
     svg.value = svgElement.outerHTML
   } finally {
-    viewer.destroy()
     document.body.removeChild(container)
+    viewer.destroy()
   }
 }
 </script>

--- a/components/DmnTable.vue
+++ b/components/DmnTable.vue
@@ -1,6 +1,7 @@
 <template>
   <div :style="{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
     <p v-if="loading">Loading DMN decision table...</p>
+    <p v-else-if="error" class="text-red-500">{{ error }}</p>
     <div ref="containerRef"
          class="dmn-table-wrapper"
          :class="{ 'hide-annotations': !props.showAnnotations }"
@@ -15,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import DmnViewer from 'dmn-js/lib/Viewer'
 import 'dmn-js/dist/assets/diagram-js.css'
 import 'dmn-js/dist/assets/dmn-js-shared.css'
@@ -25,6 +26,7 @@ import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css'
 import { onSlideEnter } from '@slidev/client'
 
 const loading = ref(false)
+const error = ref<string | null>(null)
 const containerRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
 
@@ -42,7 +44,7 @@ const props = withDefaults(defineProps<{
   showAnnotations: false,
 })
 
-const containerHeight = props.height === 'auto' ? '500px' : props.height
+const containerHeight = computed(() => props.height === 'auto' ? '500px' : props.height)
 
 /**
  * Polls for container dimensions to be ready before rendering.
@@ -71,6 +73,7 @@ async function renderDmnTable() {
   if (isRendered.value) return
   isRendered.value = true
   loading.value = true
+  error.value = null
 
   try {
     await waitForContainer()
@@ -100,6 +103,7 @@ async function renderDmnTable() {
 
   } catch (err) {
     isRendered.value = false
+    error.value = `Failed to load DMN: ${err instanceof Error ? err.message : String(err)}`
     console.error('DMN loading error:', err)
   } finally {
     loading.value = false


### PR DESCRIPTION
## Summary
- Use `v-else-if` chain in DmnDrd template to prevent flash of both loading + error states
- Add error UI to DmnTable — was silently swallowing errors, leaving users with a blank slide on failure
- Make `containerHeight` reactive via `computed()` in DmnTable
- Reverse cleanup order in DmnDrd `finally` block (remove DOM node before destroying viewer)
- Add `--provenance` flag to npm publish workflow for supply chain transparency
- Remove duplicate `.gitignore` entry

## Test plan
- [ ] Run `npm run dev` and verify DmnDrd renders correctly
- [ ] Run `npm run dev` and verify DmnTable renders correctly
- [ ] Test DmnDrd with an invalid file path — should show red error message
- [ ] Test DmnTable with an invalid file path — should show red error message
- [ ] Verify PDF export still works (`npm run export`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)