### PR TITLE
docs: add cross-reference to slidev-addon-bpmn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# slidev-addon-dmn
+# 📊 slidev-addon-dmn
 
 [![npm version](https://img.shields.io/npm/v/slidev-addon-dmn)](https://www.npmjs.com/package/slidev-addon-dmn)
 [![license](https://img.shields.io/npm/l/slidev-addon-dmn)](https://github.com/emaarco/slidev-addon-dmn/blob/main/LICENSE)
 [![live demo](https://img.shields.io/badge/live%20demo-GitHub%20Pages-blue)](https://emaarco.github.io/slidev-addon-dmn/)
 
-Display DMN decision tables and DRD diagrams in your [Slidev](https://sli.dev/) presentations. Whether you're presenting decision logic, explaining business rules, or teaching DMN concepts — this addon has you covered!
+Display DMN decision tables and DRD diagrams in your [Slidev](https://sli.dev/) presentations. Whether you're presenting decision logic, explaining business rules, or teaching DMN concepts — this addon has you covered! 💡
 
 Powered by [dmn-js](https://bpmn.io/toolkit/dmn-js/) from bpmn.io.
 
-## Quick Start
+## 🚀 Quick Start
 
 1. Install the addon in your Slidev project
 2. Place your `.dmn` files in the `public/` folder
@@ -20,7 +20,7 @@ That's it — your DMN diagrams are ready to present!
 
 ![Example DMN diagram in Slidev](./public/addon.gif)
 
-## Installation
+## 📦 Installation
 
 ```bash
 npm install slidev-addon-dmn
@@ -45,14 +45,14 @@ Or in your `package.json`:
 }
 ```
 
-## Components
+## 🧩 Components
 
 This addon provides two complementary components for different use cases:
 
 - **`<DmnDrd>`** - Static DRD rendering for PDFs, presentations, and documentation
 - **`<DmnTable>`** - Decision Table rendering for visualizing business rules
 
-## Component Reference
+## 🔧 Component Reference
 
 ### DmnDrd Component
 
@@ -98,7 +98,7 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 | `fontSize` | `string` | `'12px'` | Font size of the table content |
 | `showAnnotations` | `boolean` | `false` | Show or hide the annotations column |
 
-## Tips
+## 💡 Tips
 
 - **File location**: DMN files must be placed in the `public/` folder
 - **Supported formats**: Standard DMN 1.3 XML files (exported from Camunda Modeler, bpmn.io, etc.)
@@ -112,13 +112,13 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 > [slidev-addon-bpmn](https://github.com/emaarco/slidev-addon-bpmn) — the sister addon for rendering
 > BPMN diagrams in Slidev!
 
-## Contributing
+## 🤝 Contributing
 
 Contributions are welcome! Feel free to report bugs, suggest features via [issues](https://github.com/emaarco/slidev-addon-dmn/issues), submit pull requests with improvements, or share your ideas and use cases.
 
 To develop locally: clone the repo, run `npm install`, then `npm run dev` to test your changes.
 
-## Credits
+## 🙏 Credits
 
 - [dmn-js](https://github.com/bpmn-io/dmn-js) by [bpmn.io](https://bpmn.io/)
-- [bavaria-ipsum](https://bavaria-ipsum.de/) - for making the example slide a little more entertaining
+- [bavaria-ipsum](https://bavaria-ipsum.de/) - for making the example slide a little more entertaining 🥨

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 - **Styling**: Use Tailwind classes via the `class` prop to control sizing
 - **Export**: The `<DmnDrd>` component works seamlessly with Slidev's PDF/PNG export features
 
+## 🔗 Related
+
+> **Looking for BPMN?** If you're modeling business processes alongside your decisions, check out
+> [slidev-addon-bpmn](https://github.com/emaarco/slidev-addon-bpmn) — the sister addon for rendering
+> BPMN diagrams in Slidev!
+
 ## Contributing
 
 Contributions are welcome! Feel free to report bugs, suggest features via [issues](https://github.com/emaarco/slidev-addon-dmn/issues), submit pull requests with improvements, or share your ideas and use cases.
@@ -115,5 +121,4 @@ To develop locally: clone the repo, run `npm install`, then `npm run dev` to tes
 ## Credits
 
 - [dmn-js](https://github.com/bpmn-io/dmn-js) by [bpmn.io](https://bpmn.io/)
-- Inspired by [slidev-addon-bpmn](https://github.com/emaarco/slidev-addon-bpmn)
 - [bavaria-ipsum](https://bavaria-ipsum.de/) - for making the example slide a little more entertaining


### PR DESCRIPTION
## Summary
- Adds a visible "Related" section to the README linking to [slidev-addon-bpmn](https://github.com/emaarco/slidev-addon-bpmn)
- Removes the now-redundant mention from Credits

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)