### PR TITLE
ci: add pin-npm-dependencies check to build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: Miragon/pin-npm-dependencies@v1.0.0
+      - uses: Miragon/pin-npm-dependencies@v1
         with:
           files: package.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: Miragon/pin-npm-dependencies@v1.0.0
+        with:
+          files: package.json
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary

- Adds `Miragon/pin-npm-dependencies@v1.0.0` as an early step in the build workflow
- Explicitly checks `package.json` for version ranges (`^`, `~`) and fails the build if any are found
- Runs before Node setup for fast feedback on PRs

## Test plan

- [ ] Verify the build passes on this PR (all deps are already pinned)
- [ ] Confirm a test PR with a range like `"lodash": "^4.0.0"` fails the check