### PR TITLE
build(deps): split dependabot prod vs dev for changelog visibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Config for npm dependencies
+  # Production npm dependencies — surfaced in CHANGELOG as `fix(deps)`
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -9,8 +9,12 @@ updates:
       - "dependencies"
     assignees:
       - "emaarco"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
     groups:
-      dependencies:
+      production-dependencies:
+        dependency-type: "production"
         patterns:
           - "*"
         update-types:
@@ -19,7 +23,30 @@ updates:
           - "major"
     open-pull-requests-limit: 2
 
-  # Config for GitHub Actions
+  # Development npm dependencies — hidden from CHANGELOG as `chore(deps-dev)`
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    assignees:
+      - "emaarco"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+          - "major"
+    open-pull-requests-limit: 2
+
+  # GitHub Actions — hidden from CHANGELOG as `chore(deps)`
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -28,6 +55,9 @@ updates:
       - "dependencies"
     assignees:
       - "emaarco"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary
- Splits the single npm dependabot entry into two: production deps and development deps
- Production bumps now commit as `fix(deps): ...` so release-please includes them in the CHANGELOG (and triggers a patch release — runtime bumps affect consumers of this addon)
- Dev deps and GitHub Actions commit as `chore(deps[-dev]): ...` and remain hidden from the CHANGELOG, keeping noise low

## Why
Today every dependabot PR lands as `build(deps): ...` / `build(deps-dev): ...`. release-please hides the `build` type by default, so even bumps of our only runtime dep (`dmn-js`) silently disappear from the changelog. Consumers of `slidev-addon-dmn` can't tell from the release notes that the embedded `dmn-js` version changed.

## Behavior after merge
| Update | Commit prefix | In CHANGELOG? | Triggers release? |
|---|---|---|---|
| `dmn-js` bump | `fix(deps): ...` | Yes (Bug Fixes) | Yes (patch) |
| devDep bump (vitest, slidev, …) | `chore(deps-dev): ...` | No | No |
| GitHub Actions bump | `chore(deps): ...` | No | No |

## Test plan
- [ ] Merge and wait for the next dependabot run; verify production vs dev PRs use the expected prefixes
- [ ] Confirm a `dmn-js` bump (when it arrives) appears in the release-please PR diff to `CHANGELOG.md`