### PR TITLE
docs: backfill historical changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.0.0](https://github.com/emaarco/slidev-addon-dmn/releases/tag/v1.0.0) (2026-05-27)
+
+### Features
+
+* add GitHub Pages live demo deployment ([#6](https://github.com/emaarco/slidev-addon-dmn/issues/6)) ([151d6ec](https://github.com/emaarco/slidev-addon-dmn/commit/151d6ec765781cc1814f5f02afa70bacfa220189))
+* add vitest tests and CI pipeline ([#10](https://github.com/emaarco/slidev-addon-dmn/issues/10)) ([14ac79f](https://github.com/emaarco/slidev-addon-dmn/commit/14ac79f5f8ad81750b62ffa2306e3c874c9e58f2))
+* slidev addon for rendering DMN diagrams ([eac3671](https://github.com/emaarco/slidev-addon-dmn/commit/eac3671612f3c82930ae88b7a523a3c5d35e1262))
+
+### Bug Fixes
+
+* improve error handling and minor cleanups ([#4](https://github.com/emaarco/slidev-addon-dmn/issues/4)) ([a3e5b40](https://github.com/emaarco/slidev-addon-dmn/commit/a3e5b40ab1c063d0db3ae8ff384ae18fd4be2056))


### PR DESCRIPTION
## Summary
- Generates the missing `CHANGELOG.md` for everything up to and including `v1.0.0` using `npx conventional-changelog-cli -p conventionalcommits -r 0`.
- Header normalized to the release-please format (`## [1.0.0](...)`) so future release-please runs prepend new versions cleanly above this entry.

## Why
After the initial release-please setup (#17) the `v1.0.0` release shipped without any historical changelog — release-please only tracks commits *after* its first tag. This backfills the history retroactively.

## Test plan
- [ ] Visual check of `CHANGELOG.md` content
- [ ] Confirm next release-please PR prepends new section above `## [1.0.0]` without breaking the existing entry