### PR TITLE
ci: fix npm publish (OIDC) and wire GitHub Pages into release-please

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,15 @@ jobs:
       - run: npm run build --if-present
       - run: npm publish --provenance
 
+  deploy-pages:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' && inputs.dry_run != true }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-pages.yml
+
   publish-dry-run:
     needs: release-please
     if: ${{ inputs.dry_run == true }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,9 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' && inputs.dry_run != true }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,6 +44,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --provenance
@@ -49,12 +53,16 @@ jobs:
     needs: release-please
     if: ${{ inputs.dry_run == true }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --provenance --dry-run

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --provenance
@@ -62,7 +61,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --provenance --dry-run


### PR DESCRIPTION
## Why

Two release-pipeline issues, same root cause class.

1. **npm publish 404'd** on `1.1.0`. `npm publish` fell back to an empty token because no Trusted Publisher was configured on npmjs.com. (Now configured — re-run published `1.1.0` successfully.)
2. **GitHub Pages never updated.** `deploy-pages.yml` and `npm-publish.yml` both trigger on `release: published`, but releases created by `release-please-action` use the default `GITHUB_TOKEN`, and GitHub suppresses downstream workflow triggers from `GITHUB_TOKEN`-created events. So those workflows never auto-ran.

## Changes

- **release-please.yml**: scope `id-token: write` (+ `contents: read`) to the publish job (least privilege).
- **deploy-pages.yml**: convert to a reusable workflow (`on: workflow_call` + `workflow_dispatch`); drop the dead `release:` trigger.
- **release-please.yml**: add a `deploy-pages` job that `uses: ./.github/workflows/deploy-pages.yml`, gated on `release_created`, mirroring the publish job.

A single release run now: create release → publish to npm → deploy Pages.

## Notes

- Trusted Publisher is configured on npmjs.com (https://www.npmjs.com/package/slidev-addon-dmn/access).
- `npm-publish.yml` is now dead code (release-triggered, never fires; publishing lives in release-please.yml). Left in place for a follow-up cleanup.