### PR TITLE
ci: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,15 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
+      - id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           dry-run: ${{ inputs.dry_run == true }}


### PR DESCRIPTION
## What

Mint a GitHub App token in the `release-please` job and pass it to `googleapis/release-please-action` via its `token:` input, replacing the implicit `GITHUB_TOKEN`.

- Add an `actions/create-github-app-token@v2` step (`id: app-token`) before the release-please step, using `vars.RELEASE_PLEASE_APP_ID` + `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`.
- Wire `token: ${{ steps.app-token.outputs.token }}` into the release-please step.

No other inputs, permissions, or jobs changed.

## Why

Events created with the built-in `GITHUB_TOKEN` are suppressed by GitHub's loop-prevention, so release-please PRs and release tags don't trigger downstream CI. Using a GitHub App token fixes this and attributes the commits/tags/releases to a named bot.

Mirrors emaarco/slidev-addon-bpmn#63.

## Notes

The required `RELEASE_PLEASE_APP_ID` variable and `RELEASE_PLEASE_APP_PRIVATE_KEY` secret are already configured on this repo; no secret changes are part of this PR.