### PR TITLE
ci: add dependabot cooldown and bump dependency-review to v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
     labels:
       - "dependencies"
     assignees:
@@ -24,6 +26,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
     labels:
       - "dependencies"
     assignees:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
 
       - uses: Miragon/pin-npm-dependencies@7bd516fed2bbbfdd395772661f8e8cf8731bacae # v1
         with:


### PR DESCRIPTION
## What

Backports the two pieces from [slidev-addon-bpmn#64](https://github.com/emaarco/slidev-addon-bpmn/pull/64) that this repo was still missing:

- **Dependabot cooldown** — adds `cooldown: default-days: 5` to both the npm (weekly) and github-actions (monthly) update blocks. Dependabot now waits 5 days after a release before opening update PRs, giving the ecosystem time to flag a freshly-published (potentially compromised) version before we pull it in.
- **dependency-review-action v4 → v5** — bumps the SHA-pinned dep-review job in `build.yml` to v5 (`@a1d282b3`), matching the BPMN repo.

## Why

Aligns this addon's supply-chain hardening with slidev-addon-bpmn. Everything else from that PR (SHA-pinned actions, `pr-title.yml`, `environment:` on the publish job) was already present here.
