### PR TITLE
feat: add interactive DmnModeler component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,10 @@ npm run screenshot
 
 ### Core Components
 
-The addon consists of two Vue components:
+The addon consists of three Vue components, backed by shared helpers in `composables/`
+(`useDmn.ts` — fetch + loading/error state), `internal/` (`ToolbarButton.vue`, `fitDiagram.ts`)
+and `engines/` (`camunda.ts` — properties-panel config). The `composables/`, `internal/` and
+`engines/` directories are published to npm alongside `components/`.
 
 #### `components/DmnDrd.vue`
 1. **Fetches DMN XML**: Loads `.dmn` files from the `public/` folder via fetch
@@ -40,6 +43,13 @@ The addon consists of two Vue components:
 3. **Opens decision table view**: Navigates to the specified decision table (or first found)
 4. **Dual lifecycle**: Uses both `onMounted` and `onSlideEnter` for PDF export and live preview compatibility
 
+#### `components/DmnModeler.vue`
+1. **Thumbnail viewer**: Renders a read-only DRD preview in the slide (`dmn-js/lib/Viewer`), fit via `fitDiagram`
+2. **Fullscreen editor**: An "Edit" button opens an interactive `dmn-js/lib/Modeler` in a `<Teleport>` overlay; edit the DRD and double-click a decision to edit its table
+3. **Save-on-close**: On close, `saveXML()` is compared to the loaded XML; if changed, the slide thumbnail re-renders
+4. **Optional Camunda panel**: With `engine="camunda"`, mounts `dmn-js-properties-panel` (config nested under the modeler's `drd:` key) with a hide/show toggle
+5. **Blank canvas**: With no `dmnFilePath`, imports a minimal blank DMN template so the modeler opens ready to edit
+
 ### Key Implementation Details
 
 - DmnDrd uses an **off-screen rendering approach** because dmn-js requires a DOM element to render DRD diagrams as SVG
@@ -47,6 +57,7 @@ The addon consists of two Vue components:
 - The off-screen container has a **fixed 1920x1080 size** for DRD rendering
 - SVG sizing is controlled via `maxWidth` and `height` style properties with `preserveAspectRatio="xMidYMid meet"` for responsive scaling
 - DMN file paths are resolved relative to `window.location.origin + import.meta.env.BASE_URL`
+- DmnModeler nests `additionalModules`/`propertiesPanel` under a **`drd:` key** (dmn-js modelers are composed of per-view editors), with `moddleExtensions` at the top level
 
 ### Vite Configuration
 
@@ -55,7 +66,8 @@ The `vite.config.ts` file is **critical** for this addon to work. It includes dm
 ## Package Distribution
 
 The npm package includes only:
-- `components/` directory (DmnDrd.vue and DmnTable.vue)
+- `components/` directory (DmnDrd.vue, DmnTable.vue, DmnModeler.vue)
+- `composables/`, `internal/`, `engines/` directories (shared helpers used by the components)
 - `vite.config.ts` (required Vite configuration)
 
 Everything else (`example.md`, `public/`, `docs/`) is excluded via the `files` field in package.json.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Powered by [dmn-js](https://bpmn.io/toolkit/dmn-js/) from bpmn.io.
 
 1. Install the addon in your Slidev project
 2. Place your `.dmn` files in the `public/` folder
-3. Use the `<DmnDrd>` or `<DmnTable>` components in your slides
+3. Use the `<DmnDrd>`, `<DmnTable>` or `<DmnModeler>` components in your slides
 
 That's it — your DMN diagrams are ready to present!
 
@@ -47,10 +47,11 @@ Or in your `package.json`:
 
 ## 🧩 Components
 
-This addon provides two complementary components for different use cases:
+This addon provides three complementary components for different use cases:
 
 - **`<DmnDrd>`** - Static DRD rendering for PDFs, presentations, and documentation
 - **`<DmnTable>`** - Decision Table rendering for visualizing business rules
+- **`<DmnModeler>`** - Interactive DMN modeler for live editing during workshops and trainings, with an optional Camunda properties panel
 
 ## 🔧 Component Reference
 
@@ -97,6 +98,41 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 | `decisionId` | `string` | *first found* | ID of the decision to display (optional, defaults to the first decision table) |
 | `fontSize` | `string` | `'12px'` | Font size of the table content |
 | `showAnnotations` | `boolean` | `false` | Show or hide the annotations column |
+
+### DmnModeler Component
+
+Embeds an interactive DMN modeler for live editing. A thumbnail of the DRD is shown in the slide; clicking **Edit** opens the model fullscreen where you can rearrange the DRD and double-click a decision to edit its table. On **Close**, any changes are reflected back in the slide thumbnail. Ideal for workshops, trainings, and collaborative sessions.
+
+```vue
+<DmnModeler
+  dmnFilePath="./my-decisions.dmn"
+  width="100%"
+  height="500px"
+/>
+```
+
+Or start with a blank canvas:
+
+```vue
+<DmnModeler height="500px" />
+```
+
+Pass `engine="camunda"` to mount the Camunda properties panel side-by-side with the canvas, so you can edit ids, names, and Camunda-specific execution properties live:
+
+```vue
+<DmnModeler dmnFilePath="./my-decisions.dmn" engine="camunda" height="500px" />
+```
+
+In fullscreen mode, the panel can be hidden and shown again via the toolbar — handy when you need the full canvas width.
+
+**Props:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `dmnFilePath` | `string` | — | Optional path to a `.dmn` file (relative to `public/`). Omit for a blank diagram. |
+| `width` | `string` | `'100%'` | Width of the modeler container |
+| `height` | `string` | `'500px'` | Height of the modeler container |
+| `engine` | `'camunda'` | — | Optional engine. Mounts a `dmn-js-properties-panel` configured for Camunda. Omit for a panel-less modeler. |
 
 ## 💡 Tips
 

--- a/components/DmnDrd.vue
+++ b/components/DmnDrd.vue
@@ -13,9 +13,9 @@ import 'dmn-js/dist/assets/diagram-js.css'
 import 'dmn-js/dist/assets/dmn-js-shared.css'
 import 'dmn-js/dist/assets/dmn-js-drd.css'
 import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css'
+import { useDmn } from '../composables/useDmn'
 
-const loading = ref(false)
-const error = ref<string | null>(null)
+const { loading, error, fetchDmnXml, withLoading } = useDmn()
 const svg = ref<string | null>(null)
 
 const props = withDefaults(defineProps<{
@@ -29,29 +29,12 @@ const props = withDefaults(defineProps<{
   fontSize: '12px',
 })
 
-onMounted(async () => {
-  loading.value = true
-  error.value = null
-
-  try {
-    await loadAndRenderDrd(props.dmnFilePath)
-  } catch (err) {
-    error.value = `Failed to load DMN: ${err instanceof Error ? err.message : String(err)}`
-    console.error('DMN loading error:', err)
-  } finally {
-    loading.value = false
-  }
+onMounted(() => {
+  withLoading(() => loadAndRenderDrd(props.dmnFilePath))
 })
 
 async function loadAndRenderDrd(path: string): Promise<void> {
-  const url = new URL(path, window.location.origin + import.meta.env.BASE_URL).href
-  const response = await fetch(url)
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch DMN file: ${response.status}`)
-  }
-
-  const dmnXml = await response.text()
+  const dmnXml = await fetchDmnXml(path)
 
   // Create off-screen container for dmn-js rendering (requires DOM element)
   const container = document.createElement('div')

--- a/components/DmnModeler.vue
+++ b/components/DmnModeler.vue
@@ -1,0 +1,308 @@
+<template>
+  <div :style="{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', width: props.width, height: containerHeight }">
+    <p v-if="loading">Loading DMN diagram...</p>
+    <p v-if="error" class="text-red-500">{{ error }}</p>
+
+    <div ref="viewerContainerRef" class="dmn-modeler-container" :style="{
+      width: `calc(${props.width} - ${margin * 2}px)`,
+      height: `calc(${containerHeight} - ${margin * 2}px)`,
+      margin: `${margin}px`,
+    }"></div>
+
+    <ToolbarButton
+      v-if="!loading && !error"
+      title="Open modeler"
+      label="Edit"
+      :position="{ top: '12px', right: '12px', zIndex: 10 }"
+      @click="openFullscreen"
+    >
+      <template #icon>
+        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+        </svg>
+      </template>
+    </ToolbarButton>
+
+    <Teleport to="body">
+      <div
+        v-if="isFullscreen"
+        :style="{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          zIndex: 9999,
+          background: 'white',
+          display: 'flex',
+        }"
+        @keydown.stop
+      >
+        <div :style="{ flex: 1, height: '100%', position: 'relative' }">
+          <div ref="modelerContainerRef" :style="{ width: '100%', height: '100%' }"></div>
+
+          <div :style="{
+            position: 'absolute',
+            top: '16px',
+            right: '16px',
+            zIndex: 10000,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'stretch',
+            gap: '8px',
+          }">
+            <ToolbarButton
+              title="Close modeler"
+              label="Close"
+              @click="closeFullscreen"
+            >
+              <template #icon>
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"/>
+                  <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+              </template>
+            </ToolbarButton>
+            <ToolbarButton
+              v-if="props.engine"
+              :title="isPanelOpen ? 'Hide properties panel' : 'Show properties panel'"
+              :label="isPanelOpen ? 'Hide panel' : 'Show panel'"
+              @click="togglePanel"
+            >
+              <template #icon>
+                <svg v-if="isPanelOpen" xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="9 18 15 12 9 6"/>
+                </svg>
+                <svg v-else xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="15 18 9 12 15 6"/>
+                </svg>
+              </template>
+            </ToolbarButton>
+          </div>
+        </div>
+
+        <div
+          v-if="props.engine"
+          v-show="isPanelOpen"
+          ref="propertiesPanelRef"
+          :style="{
+            width: '350px',
+            height: '100%',
+            overflowY: 'auto',
+            borderLeft: '1px solid #ccc',
+            background: '#fafafa',
+          }"
+        ></div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { type Ref, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import DmnViewer from 'dmn-js/lib/Viewer'
+import DmnModeler from 'dmn-js/lib/Modeler'
+import 'dmn-js/dist/assets/diagram-js.css'
+import 'dmn-js/dist/assets/dmn-js-shared.css'
+import 'dmn-js/dist/assets/dmn-js-drd.css'
+import 'dmn-js/dist/assets/dmn-js-decision-table.css'
+import 'dmn-js/dist/assets/dmn-js-decision-table-controls.css'
+import 'dmn-js/dist/assets/dmn-js-literal-expression.css'
+import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css'
+import '@bpmn-io/properties-panel/dist/assets/properties-panel.css'
+import { onSlideEnter } from '@slidev/client'
+import { useDmn } from '../composables/useDmn'
+import { camundaEngine } from '../engines/camunda'
+import type { Engine } from '../engines/types'
+import { fitDiagram } from '../internal/fitDiagram'
+import ToolbarButton from '../internal/ToolbarButton.vue'
+
+const margin = 5
+const containerWaitTimeout = 5000
+
+// A bare DMN 1.3 model with an empty DRD canvas — the starting point when no
+// `dmnFilePath` is given, so the modeler opens ready to build from scratch.
+const BLANK_DMN = `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" id="blank_definitions" name="New Decision Model" namespace="http://camunda.org/schema/1.0/dmn">
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1" />
+  </dmndi:DMNDI>
+</definitions>`
+
+const { loading, error, fetchDmnXml, withLoading } = useDmn()
+const viewerContainerRef = ref<HTMLDivElement | null>(null)
+const modelerContainerRef = ref<HTMLDivElement | null>(null)
+const propertiesPanelRef = ref<HTMLDivElement | null>(null)
+const isRendered = ref(false)
+const isFullscreen = ref(false)
+const isPanelOpen = ref(true)
+const currentXml = ref<string | null>(null)
+let viewer: any = null
+let modeler: any = null
+
+const props = withDefaults(defineProps<{
+  dmnFilePath?: string
+  width?: string
+  height?: string
+  engine?: Engine
+}>(), {
+  width: '100%',
+  height: '500px',
+})
+
+function resolveEngineConfig() {
+  if (props.engine === 'camunda') return camundaEngine
+  return null
+}
+
+const containerHeight = props.height
+
+async function waitForContainer(containerRef: Ref<HTMLDivElement | null>): Promise<boolean> {
+  return new Promise((resolve) => {
+    const start = Date.now()
+    const checkDimensions = () => {
+      if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
+        resolve(true)
+      } else if (Date.now() - start > containerWaitTimeout) {
+        resolve(false)
+      } else {
+        requestAnimationFrame(checkDimensions)
+      }
+    }
+    checkDimensions()
+  })
+}
+
+/** Fit the DRD view of a dmn-js viewer/modeler instance into its container. */
+function fitActiveDrd(instance: any): void {
+  const activeViewer = instance.getActiveViewer?.()
+  const canvas = activeViewer?.get?.('canvas')
+  if (!canvas) return
+  canvas.resized()
+  fitDiagram(canvas)
+}
+
+async function renderViewer(): Promise<boolean> {
+  if (viewer) {
+    viewer.destroy()
+    viewer = null
+  }
+
+  const ready = await waitForContainer(viewerContainerRef)
+  if (!ready) return false
+
+  viewer = new DmnViewer({ container: viewerContainerRef.value! })
+
+  if (!currentXml.value) {
+    currentXml.value = props.dmnFilePath ? await fetchDmnXml(props.dmnFilePath) : BLANK_DMN
+  }
+
+  await viewer.importXML(currentXml.value)
+
+  // Open the DRD view so the thumbnail always shows the diagram, not a table.
+  const drdView = viewer.getViews().find((v: any) => v.type === 'drd')
+  if (drdView) await viewer.open(drdView)
+  fitActiveDrd(viewer)
+
+  return true
+}
+
+async function renderDmn() {
+  if (isRendered.value) return
+  isRendered.value = true
+
+  const result = await withLoading(() => renderViewer())
+
+  // result === false → container hidden (preload). Reset guard so onSlideEnter retries.
+  // result === undefined → withLoading caught a real error.
+  if (result === false || (result === undefined && error.value)) {
+    isRendered.value = false
+  }
+}
+
+async function openFullscreen() {
+  if (!currentXml.value) return
+
+  isFullscreen.value = true
+  await nextTick()
+  await waitForContainer(modelerContainerRef)
+
+  const config = resolveEngineConfig()
+  const options: any = { container: modelerContainerRef.value! }
+  if (config) {
+    options.drd = {
+      additionalModules: config.additionalModules,
+      propertiesPanel: { parent: propertiesPanelRef.value! },
+    }
+    options.moddleExtensions = config.moddleExtensions
+  }
+  modeler = new DmnModeler(options)
+
+  await modeler.importXML(currentXml.value)
+  fitActiveDrd(modeler)
+}
+
+async function closeFullscreen() {
+  let changed = false
+
+  if (modeler) {
+    try {
+      const { xml } = await modeler.saveXML({ format: true })
+      if (xml && xml !== currentXml.value) {
+        currentXml.value = xml
+        changed = true
+      }
+    } catch (err) {
+      console.error('Failed to save DMN changes:', err)
+    }
+    modeler.destroy()
+    modeler = null
+  }
+
+  isFullscreen.value = false
+  isPanelOpen.value = true
+
+  if (changed) {
+    await nextTick()
+    await renderViewer()
+  }
+}
+
+async function togglePanel() {
+  isPanelOpen.value = !isPanelOpen.value
+  await nextTick()
+  if (modeler) {
+    const canvas = modeler.getActiveViewer?.()?.get?.('canvas')
+    canvas?.resized()
+  }
+}
+
+defineExpose({ openFullscreen, closeFullscreen, togglePanel })
+
+onMounted(async () => {
+  await nextTick()
+  await renderDmn()
+})
+
+onSlideEnter(async () => {
+  await renderDmn()
+})
+
+onUnmounted(() => {
+  viewer?.destroy()
+  viewer = null
+  modeler?.destroy()
+  modeler = null
+})
+</script>
+
+<style scoped>
+/* dmn-js watermark anchored bottom-right; shrink so it stays subordinate in
+   small tiles. The fullscreen overlay uses its own viewer instance and is not
+   targeted by this scoped rule. */
+.dmn-modeler-container :deep(.bjs-powered-by) {
+  transform: scale(0.7);
+  transform-origin: bottom right;
+}
+</style>

--- a/components/DmnTable.vue
+++ b/components/DmnTable.vue
@@ -24,9 +24,9 @@ import 'dmn-js/dist/assets/dmn-js-decision-table.css'
 import 'dmn-js/dist/assets/dmn-js-decision-table-controls.css'
 import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css'
 import { onSlideEnter } from '@slidev/client'
+import { useDmn } from '../composables/useDmn'
 
-const loading = ref(false)
-const error = ref<string | null>(null)
+const { loading, error, fetchDmnXml } = useDmn()
 const containerRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
 
@@ -77,12 +77,7 @@ async function renderDmnTable() {
 
   try {
     await waitForContainer()
-    const url = new URL(props.dmnFilePath, window.location.origin + import.meta.env.BASE_URL).href
-    const response = await fetch(url)
-
-    if (!response.ok) throw new Error(`Failed to fetch DMN file: ${response.status}`)
-
-    const dmnXml = await response.text()
+    const dmnXml = await fetchDmnXml(props.dmnFilePath)
     const viewer = new DmnViewer({
       container: containerRef.value!,
     })

--- a/composables/useDmn.ts
+++ b/composables/useDmn.ts
@@ -1,0 +1,36 @@
+import { ref } from 'vue'
+
+/**
+ * Shared loading/error state and DMN XML fetching for the DMN components.
+ * Mirrors the structure of the sister addon (slidev-addon-bpmn) so both
+ * code bases stay easy to read side by side.
+ */
+export function useDmn() {
+  const loading = ref(true)
+  const error = ref<string | null>(null)
+
+  async function fetchDmnXml(path: string): Promise<string> {
+    const url = new URL(path, window.location.origin + import.meta.env.BASE_URL).href
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch DMN file: ${response.status}`)
+    }
+    return response.text()
+  }
+
+  async function withLoading<T>(fn: () => Promise<T>): Promise<T | undefined> {
+    loading.value = true
+    error.value = null
+    try {
+      return await fn()
+    } catch (err) {
+      error.value = `Failed to load DMN: ${err instanceof Error ? err.message : String(err)}`
+      console.error('DMN loading error:', err)
+      return undefined
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { loading, error, fetchDmnXml, withLoading }
+}

--- a/engines/camunda.ts
+++ b/engines/camunda.ts
@@ -1,0 +1,23 @@
+import {
+  DmnPropertiesPanelModule,
+  DmnPropertiesProviderModule,
+  CamundaPropertiesProviderModule,
+} from 'dmn-js-properties-panel'
+import camundaModdle from 'camunda-dmn-moddle/resources/camunda.json'
+import type { EngineConfig } from './types'
+
+/**
+ * Camunda Platform properties panel for the DMN modeler.
+ *
+ * The modules are passed to the modeler under its `drd:` key, while the moddle
+ * extension is registered at the top level so the `camunda:` namespace is known
+ * during import, editing and export.
+ */
+export const camundaEngine: EngineConfig = {
+  additionalModules: [
+    DmnPropertiesPanelModule,
+    DmnPropertiesProviderModule,
+    CamundaPropertiesProviderModule,
+  ],
+  moddleExtensions: { camunda: camundaModdle },
+}

--- a/engines/types.ts
+++ b/engines/types.ts
@@ -1,0 +1,6 @@
+export type Engine = 'camunda'
+
+export interface EngineConfig {
+  additionalModules: any[]
+  moddleExtensions: Record<string, any>
+}

--- a/example.md
+++ b/example.md
@@ -2,32 +2,6 @@
 colorSchema: light
 ---
 
-<style>
-h1 {
-  color: #335DE4;
-  font-weight: bold;
-  margin-bottom: 0;
-}
-
-h2 {
-  color: #1E3A8A;
-  font-weight: bold;
-  margin-bottom: 1rem;
-}
-
-p {
-  color: #6b7280;
-  margin-bottom: 1rem;
-}
-
-code {
-  color: #9333ea;
-  background: #f3f4f6;
-  padding: 2px 6px;
-  border-radius: 4px;
-}
-</style>
-
 # slidev-addon-dmn
 
 Embed your DMN models direkt and gscheid – because screenshot Gefrickel is just zwider.

--- a/example.md
+++ b/example.md
@@ -1,3 +1,7 @@
+---
+colorSchema: light
+---
+
 <style>
 h1 {
   color: #335DE4;
@@ -33,6 +37,7 @@ No manual export chaos, just saubere decision diagrams!
 **Features:**
 - Static DRD rendering for PDFs and presentations
 - Decision Table rendering for rule visualization
+- Live DMN modeling for workshops and trainings
 
 ---
 
@@ -49,3 +54,27 @@ The `DmnDrd` component renders Decision Requirements Diagrams as static SVG imag
 The `DmnTable` component renders Decision Tables directly – the rules laid out sauber and klar! Your audience kapiert sofort how the decisions are made, koa langweiliges Gschwafel needed!
 
 <DmnTable dmnFilePath="./example.dmn" height="350px" fontSize="11px"></DmnTable>
+
+---
+
+## Live DMN Modeler
+
+The `DmnModeler` component embeds an editable diagram – hit **Edit** and the DMN opens fullscreen. Tweak the DRD, double-click the **Dish** decision to edit its table live, then **Close** and the slide reflects your changes. Ideal for workshops where you build decisions together with your audience!
+
+<DmnModeler dmnFilePath="./example.dmn" height="350px"></DmnModeler>
+
+---
+
+## Modeler with Camunda Panel
+
+Pass `engine="camunda"` and you get the Camunda properties panel side-by-side – edit ids, names and execution-related Camunda properties without Tool-Hopserei. The panel can be hidden via the toolbar when you need the full canvas.
+
+<DmnModeler dmnFilePath="./example.dmn" engine="camunda" height="350px"></DmnModeler>
+
+---
+
+## Blank Canvas Modeler
+
+No `dmnFilePath`? Dann gibt's nur die Zeichenfläche – a bare modeler for building a decision model from scratch in a live session.
+
+<DmnModeler height="350px"></DmnModeler>

--- a/internal/ToolbarButton.vue
+++ b/internal/ToolbarButton.vue
@@ -1,0 +1,41 @@
+<template>
+  <button :style="resolvedStyle" :title="props.title" @click="emit('click', $event)">
+    <slot name="icon" />
+    <span v-if="props.label">{{ props.label }}</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { type CSSProperties, computed } from 'vue'
+
+const props = defineProps<{
+  title: string
+  label?: string
+  position?: { top?: string; right?: string; bottom?: string; left?: string; zIndex?: number }
+}>()
+
+const emit = defineEmits<{ (e: 'click', ev: MouseEvent): void }>()
+
+const baseStyle: CSSProperties = {
+  cursor: 'pointer',
+  background: 'white',
+  border: '1px solid #ccc',
+  borderRadius: '3px',
+  padding: '3px 6px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '3px',
+  // Lock to a system UI font so the button always reads as a control rather than
+  // inheriting the deck theme's display/serif font.
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+  fontSize: '11px',
+  lineHeight: '1',
+  color: '#333',
+  boxShadow: '0 1px 2px rgba(0,0,0,0.08)',
+}
+
+const resolvedStyle = computed<CSSProperties>(() => {
+  if (!props.position) return baseStyle
+  return { ...baseStyle, position: 'absolute', ...props.position }
+})
+</script>

--- a/internal/fitDiagram.ts
+++ b/internal/fitDiagram.ts
@@ -1,0 +1,57 @@
+// Centre the diagram in the canvas with a relative pad on every side.
+// Pad is computed against the diagram's own larger dimension so the visual
+// margin stays proportional regardless of card size.
+const DIAGRAM_PADDING_RATIO = 0.05
+
+// Never enlarge a diagram beyond its native pixel size — image-viewer rule.
+// Without this, a near-empty diagram (e.g. a single decision) balloons to
+// fill the card and looks absurd.
+const MAX_SCALE = 1
+
+// canvas: diagram-js Canvas service (typed loosely to mirror existing call-sites).
+export function fitDiagram(canvas: any, ratio: number = DIAGRAM_PADDING_RATIO): void {
+  const view = canvas.viewbox()
+  const inner = view?.inner
+  const outer = view?.outer
+  if (!inner || !inner.width || !inner.height) return
+  if (!outer || !outer.width || !outer.height) return
+
+  // 1. Pad the inner bbox proportionally on every side.
+  const pad = Math.max(inner.width, inner.height) * ratio
+  let x = inner.x - pad
+  let y = inner.y - pad
+  let width = inner.width + pad * 2
+  let height = inner.height + pad * 2
+
+  // 2. If fitting would enlarge beyond MAX_SCALE, clamp at native and centre
+  // on the diagram's bbox centre.
+  const fitScale = Math.min(outer.width / width, outer.height / height)
+  if (fitScale > MAX_SCALE) {
+    const cx = inner.x + inner.width / 2
+    const cy = inner.y + inner.height / 2
+    canvas.viewbox({
+      x: cx - outer.width / (2 * MAX_SCALE),
+      y: cy - outer.height / (2 * MAX_SCALE),
+      width: outer.width / MAX_SCALE,
+      height: outer.height / MAX_SCALE,
+    })
+    return
+  }
+
+  // 3. Expand the slacker axis so the box matches the outer aspect ratio.
+  // diagram-js fits with min-scale and anchors the box's top-left at the canvas
+  // origin, which would otherwise leave the slack on one side only.
+  const outerAspect = outer.width / outer.height
+  const boxAspect = width / height
+  if (boxAspect < outerAspect) {
+    const newWidth = height * outerAspect
+    x -= (newWidth - width) / 2
+    width = newWidth
+  } else if (boxAspect > outerAspect) {
+    const newHeight = width / outerAspect
+    y -= (newHeight - height) / 2
+    height = newHeight
+  }
+
+  canvas.viewbox({ x, y, width, height })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "dmn-js": "17.8.1"
+        "@bpmn-io/properties-panel": "3.44.1",
+        "camunda-dmn-moddle": "1.3.1",
+        "dmn-js": "17.8.1",
+        "dmn-js-properties-panel": "3.11.1"
       },
       "devDependencies": {
         "@slidev/cli": "52.16.0",
@@ -551,6 +554,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bpmn-io/cm-theme": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.3.1",
+        "@codemirror/view": "^6.5.1",
+        "@lezer/highlight": "^1.1.4"
+      },
+      "workspaces": {
+        "packages": [
+          "preview-themes"
+        ]
+      }
+    },
     "node_modules/@bpmn-io/diagram-js-ui": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
@@ -603,6 +622,21 @@
         "node": "*"
       }
     },
+    "node_modules/@bpmn-io/feelin": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feelin/-/feelin-6.1.0.tgz",
+      "integrity": "sha512-nqmmlHRD9tl0ZcpYTEkZdpc/rAMoYc+ct0SOg9fFIFWRaEApme3DuXC7v9AMA5g+upGCKd6cUc3t97y+unpfMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@lezer/common": "^1.5.0",
+        "luxon": "^3.7.2",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/@bpmn-io/lang-feel": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-3.0.0.tgz",
@@ -632,6 +666,31 @@
         "node": ">= 20.12.0"
       }
     },
+    "node_modules/@bpmn-io/properties-panel": {
+      "version": "3.44.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.44.1.tgz",
+      "integrity": "sha512-8kQ59l7a9Bgfq1qvs0sTykcfqimwuJYrZPjNvr1f5OFFr+cpe3e380Pzxz9OGKk4Con1INEqVIePlaNhzrbDJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-editor": "^2.5.2",
+        "@carbon/icons": "^11.69.0",
+        "@codemirror/autocomplete": "^6.18.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/language": "^6.11.0",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.28.1",
+        "classnames": "^2.5.1",
+        "feelers": "^1.5.1",
+        "focus-trap": "^8.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -657,6 +716,16 @@
       "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.2.0.tgz",
       "integrity": "sha512-dtfv9TSDiTEivARL2l8qawxsQi9BBajoSUQQIlVXVBwt5rp/FQ9UD2DTzki//RnLnu2V2O69SxGZDhWTT28qQg==",
       "license": "MIT"
+    },
+    "node_modules/@carbon/icons": {
+      "version": "11.82.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.82.0.tgz",
+      "integrity": "sha512-XMJiHEUKd9/4kJKLbzbHX2KizUVb6mrzJbJg9gb03jYVq+tFjxUO8WmT6czmHls0mj3mv0Y2rMeMtl7/v+aQjw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
     },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
@@ -687,6 +756,16 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.27.0",
         "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
@@ -1019,6 +1098,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ibm/telemetry-js": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.11.0.tgz",
+      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ibmtelemetry": "dist/collect.js"
+      }
+    },
     "node_modules/@iconify-json/carbon": {
       "version": "1.2.23",
       "resolved": "https://registry.npmjs.org/@iconify-json/carbon/-/carbon-1.2.23.tgz",
@@ -1230,6 +1318,17 @@
         "@lezer/common": "^1.3.0"
       }
     },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
     "node_modules/@lezer/lr": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
@@ -1237,6 +1336,16 @@
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.4.tgz",
+      "integrity": "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@lillallol/outline-pdf": {
@@ -5569,6 +5678,12 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/camunda-dmn-moddle": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/camunda-dmn-moddle/-/camunda-dmn-moddle-1.3.1.tgz",
+      "integrity": "sha512-sm6lpj5Yg053fF/mZvr0NLwVoUkEieqk1blIw3Je+2Z9S7YLrcpnZxVm2DQdb2eS3bhEXKESqar+NPEKv8Vinw==",
+      "license": "MIT"
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001797",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
@@ -5669,6 +5784,12 @@
       "dependencies": {
         "consola": "^3.2.3"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cli-progress": {
       "version": "3.12.0",
@@ -6884,6 +7005,24 @@
         "table-js": "^9.4.0"
       }
     },
+    "node_modules/dmn-js-properties-panel": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/dmn-js-properties-panel/-/dmn-js-properties-panel-3.11.1.tgz",
+      "integrity": "sha512-CZY5Ngs65bUhShY6VESd5Vfu383Moc0twFE06Ov9uScSEDhdSuiCr1zmbUbm+UCB9grm0nBZ3FtP4EygvX/s3g==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "@bpmn-io/properties-panel": ">=3.7",
+        "diagram-js": ">= 14.3.1",
+        "dmn-js": ">=13"
+      }
+    },
     "node_modules/dmn-js-shared": {
       "version": "17.8.1",
       "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-17.8.1.tgz",
@@ -7341,6 +7480,37 @@
         }
       }
     },
+    "node_modules/feelers": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.5.1.tgz",
+      "integrity": "sha512-LKIAqtScSfy55Tw62DhBcxIT3k2XnppzWrkmGfsbdad0a+TxMfaLF1CSYhoVRF5FvPAUXvor1Ux/75wtBaDYpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
+        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/feelin": "^6.1.0",
+        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.1",
+        "@codemirror/language": "^6.12.1",
+        "@codemirror/lint": "^6.9.3",
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.12",
+        "@lezer/common": "^1.5.1",
+        "@lezer/highlight": "^1.1.6",
+        "@lezer/lr": "^1.4.8",
+        "@lezer/markdown": "^1.6.3",
+        "min-dom": "^5.2.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "workspaces": {
+        "packages": [
+          "feelers-playground"
+        ]
+      }
+    },
     "node_modules/file-saver": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
@@ -7415,6 +7585,15 @@
         "@nuxt/kit": {
           "optional": true
         }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.1.tgz",
+      "integrity": "sha512-6CxwrrFRquH7pDXb1mWxudkU9LSfYBMRZutpgddb2o6iwCk7cIRrBhyY3c8SGKcmIKdeMTrGSNg4Bedh2RSF/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/foreground-child": {
@@ -8757,6 +8936,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -11671,6 +11859,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/table-js": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "author": "Marco Schäck (https://github.com/emaarco)",
   "license": "MIT",
   "dependencies": {
-    "dmn-js": "17.8.1"
+    "@bpmn-io/properties-panel": "3.44.1",
+    "camunda-dmn-moddle": "1.3.1",
+    "dmn-js": "17.8.1",
+    "dmn-js-properties-panel": "3.11.1"
   },
   "devDependencies": {
     "@slidev/cli": "52.16.0",
@@ -39,9 +42,14 @@
   ],
   "files": [
     "components",
+    "composables",
+    "engines",
+    "internal",
     "vite.config.ts"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css"
+  ],
   "engines": {
     "node": ">=20"
   },

--- a/style.css
+++ b/style.css
@@ -1,0 +1,35 @@
+/*
+ * Demo deck palette for example.md.
+ * Loaded globally by Slidev because it sits next to example.md (Slidev auto-imports
+ * style.css from the project root), so the heading/text styles apply on every slide
+ * rather than only the slide a <style> block would be scoped to. Not included in the
+ * published addon — see package.json#files.
+ */
+
+.slidev-layout h1,
+h1 {
+  color: #335de4;
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+.slidev-layout h2,
+h2 {
+  color: #1e3a8a;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.slidev-layout p,
+p {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.slidev-layout code,
+code {
+  color: #9333ea;
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 4px;
+}

--- a/tests/components/DmnModeler.test.ts
+++ b/tests/components/DmnModeler.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+const {
+  mockViewerImportXML, mockViewerOpen, mockGetViews, mockViewerDestroy, mockGetActiveViewer, MockDmnViewer,
+  mockModelerImportXML, mockSaveXML, mockModelerDestroy, mockModelerGetActiveViewer, MockDmnModeler,
+} = vi.hoisted(() => ({
+  mockViewerImportXML: vi.fn(),
+  mockViewerOpen: vi.fn(),
+  mockGetViews: vi.fn(),
+  mockViewerDestroy: vi.fn(),
+  mockGetActiveViewer: vi.fn(),
+  MockDmnViewer: vi.fn(),
+  mockModelerImportXML: vi.fn(),
+  mockSaveXML: vi.fn(),
+  mockModelerDestroy: vi.fn(),
+  mockModelerGetActiveViewer: vi.fn(),
+  MockDmnModeler: vi.fn(),
+}))
+
+vi.mock('dmn-js/lib/Viewer', () => ({ default: MockDmnViewer }))
+vi.mock('dmn-js/lib/Modeler', () => ({ default: MockDmnModeler }))
+
+// Avoid importing the real properties-panel modules in unit tests.
+vi.mock('../../engines/camunda', () => ({
+  camundaEngine: { additionalModules: ['MODULE'], moddleExtensions: { camunda: {} } },
+}))
+
+const { slideEnterCallbacks } = vi.hoisted(() => ({ slideEnterCallbacks: [] as Array<() => void> }))
+vi.mock('@slidev/client', () => ({
+  onSlideEnter: vi.fn((cb: () => void) => { slideEnterCallbacks.push(cb) }),
+}))
+
+import DmnModeler from '../../components/DmnModeler.vue'
+
+const DRD_VIEW = { type: 'drd' }
+
+function mockCanvas() {
+  // viewbox() returning undefined makes fitDiagram short-circuit harmlessly.
+  return { resized: vi.fn(), viewbox: () => undefined }
+}
+
+function mockFetchSuccess(xml = '<definitions></definitions>') {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(xml) }))
+}
+
+function mockFetchFailure() {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+}
+
+// Drain the requestAnimationFrame polyfill (setTimeout 0), nextTick and promise queues.
+async function settle() {
+  for (let i = 0; i < 6; i++) {
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await flushPromises()
+  }
+}
+
+describe('DmnModeler.vue', () => {
+  beforeEach(() => {
+    slideEnterCallbacks.length = 0
+
+    // waitForContainer relies on clientWidth/clientHeight; stub them positive so
+    // both the thumbnail and the (teleported) modeler container resolve immediately.
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: 800 })
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', { configurable: true, value: 500 })
+
+    mockViewerImportXML.mockResolvedValue(undefined)
+    mockViewerOpen.mockResolvedValue(undefined)
+    mockGetViews.mockReturnValue([DRD_VIEW])
+    mockGetActiveViewer.mockReturnValue({ get: (n: string) => (n === 'canvas' ? mockCanvas() : undefined) })
+    MockDmnViewer.mockImplementation(function () {
+      return {
+        importXML: mockViewerImportXML,
+        getViews: mockGetViews,
+        open: mockViewerOpen,
+        getActiveViewer: mockGetActiveViewer,
+        destroy: mockViewerDestroy,
+      }
+    })
+
+    mockModelerImportXML.mockResolvedValue(undefined)
+    mockSaveXML.mockResolvedValue({ xml: '<definitions></definitions>' })
+    mockModelerGetActiveViewer.mockReturnValue({ get: (n: string) => (n === 'canvas' ? mockCanvas() : undefined) })
+    MockDmnModeler.mockImplementation(function () {
+      return {
+        importXML: mockModelerImportXML,
+        saveXML: mockSaveXML,
+        getActiveViewer: mockModelerGetActiveViewer,
+        destroy: mockModelerDestroy,
+      }
+    })
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    // @ts-expect-error - remove the prototype stubs added in beforeEach
+    delete HTMLElement.prototype.clientWidth
+    // @ts-expect-error
+    delete HTMLElement.prototype.clientHeight
+  })
+
+  it('shows loading state initially', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'test.dmn' } })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Loading DMN diagram...')
+  })
+
+  it('renders the DRD thumbnail after successful load', async () => {
+    mockFetchSuccess('<definitions id="x"></definitions>')
+    mount(DmnModeler, { props: { dmnFilePath: 'test.dmn' } })
+    await settle()
+
+    expect(MockDmnViewer).toHaveBeenCalled()
+    expect(mockViewerImportXML).toHaveBeenCalledWith('<definitions id="x"></definitions>')
+    expect(mockViewerOpen).toHaveBeenCalledWith(DRD_VIEW)
+  })
+
+  it('shows error on fetch failure', async () => {
+    mockFetchFailure()
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'missing.dmn' } })
+    await settle()
+
+    expect(wrapper.text()).toContain('Failed to load DMN')
+  })
+
+  it('imports a blank diagram when no dmnFilePath is given', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    mount(DmnModeler, { props: {} })
+    await settle()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(mockViewerImportXML).toHaveBeenCalledWith(expect.stringContaining('New Decision Model'))
+  })
+
+  it('opens the fullscreen modeler when the Edit button is clicked', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'test.dmn' } })
+    await settle()
+
+    const editButton = wrapper.findAll('button').find(b => b.text().includes('Edit'))
+    expect(editButton).toBeTruthy()
+    await editButton!.trigger('click')
+    await settle()
+
+    expect(MockDmnModeler).toHaveBeenCalled()
+    expect(mockModelerImportXML).toHaveBeenCalled()
+  })
+
+  it('nests the Camunda properties panel config under the drd key', async () => {
+    mockFetchSuccess()
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'test.dmn', engine: 'camunda' } })
+    await settle()
+
+    await wrapper.vm.openFullscreen()
+    await settle()
+
+    const options = MockDmnModeler.mock.calls[0][0] as any
+    expect(options.drd.additionalModules).toContain('MODULE')
+    expect(options.drd.propertiesPanel).toBeTruthy()
+    expect(options.moddleExtensions).toEqual({ camunda: {} })
+  })
+
+  it('saves and re-renders the thumbnail when the model changed on close', async () => {
+    mockFetchSuccess('<definitions id="orig"></definitions>')
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'test.dmn' } })
+    await settle()
+
+    await wrapper.vm.openFullscreen()
+    await settle()
+
+    const viewerCallsBeforeClose = MockDmnViewer.mock.calls.length
+    mockSaveXML.mockResolvedValue({ xml: '<definitions id="changed"></definitions>' })
+
+    await wrapper.vm.closeFullscreen()
+    await settle()
+
+    expect(mockSaveXML).toHaveBeenCalled()
+    expect(mockModelerDestroy).toHaveBeenCalled()
+    // Thumbnail re-rendered with the changed XML.
+    expect(MockDmnViewer.mock.calls.length).toBeGreaterThan(viewerCallsBeforeClose)
+    expect(mockViewerImportXML).toHaveBeenLastCalledWith('<definitions id="changed"></definitions>')
+  })
+
+  it('does not re-render the thumbnail when nothing changed on close', async () => {
+    mockFetchSuccess('<definitions id="orig"></definitions>')
+    const wrapper = mount(DmnModeler, { props: { dmnFilePath: 'test.dmn' } })
+    await settle()
+
+    await wrapper.vm.openFullscreen()
+    await settle()
+
+    const viewerCallsBeforeClose = MockDmnViewer.mock.calls.length
+    // saveXML returns the same XML that was loaded → no change.
+    mockSaveXML.mockResolvedValue({ xml: '<definitions id="orig"></definitions>' })
+
+    await wrapper.vm.closeFullscreen()
+    await settle()
+
+    expect(mockModelerDestroy).toHaveBeenCalled()
+    expect(MockDmnViewer.mock.calls.length).toBe(viewerCallsBeforeClose)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       'dmn-js/lib/Viewer',
+      'dmn-js/lib/Modeler',
+      'dmn-js-properties-panel',
     ],
   },
 })


### PR DESCRIPTION
## What

Adds an interactive **\`DmnModeler\`** component, reaching feature parity with the sister addon [\`slidev-addon-bpmn\`](https://github.com/emaarco/slidev-addon-bpmn) (which ships a \`BpmnModeler\`).

- **Thumbnail in the slide** — a read-only DRD preview (\`dmn-js/lib/Viewer\`) with an **Edit** button.
- **Fullscreen editor** — Edit opens a live, editable \`dmn-js/lib/Modeler\` in a \`<Teleport>\` overlay. Rearrange the DRD and double-click a decision to edit its table.
- **Save on close** — \`saveXML()\` is compared to the loaded XML; if changed, the slide thumbnail re-renders.
- **Optional Camunda panel** — \`engine="camunda"\` mounts \`dmn-js-properties-panel\` (config nested under dmn-js's \`drd:\` key) with a hide/show toggle.
- **Blank canvas** — omit \`dmnFilePath\` to build a decision model from scratch.

## Supporting changes

- New shared helpers, mirroring the brother repo's layout and published to npm: \`composables/useDmn.ts\`, \`internal/ToolbarButton.vue\`, \`internal/fitDiagram.ts\`, \`engines/{types,camunda}.ts\`.
- Refactored \`DmnDrd.vue\` / \`DmnTable.vue\` onto the new \`useDmn\` composable (behaviour unchanged).
- \`package.json\`: new deps (\`dmn-js-properties-panel\`, \`@bpmn-io/properties-panel\`, \`camunda-dmn-moddle\`), extended \`files\` field, \`sideEffects\` → \`["**/*.css"]\`.
- \`vite.config.ts\`: pre-bundle the modeler + properties panel.
- \`example.md\`: 3 new modeler slides; set \`colorSchema: light\` so the deck renders on a light background.
- Docs: \`README.md\` + \`CLAUDE.md\` updated.

## Tests / verification

- \`npm run test\` → **28/28 pass** (existing 19 + new \`DmnModeler.test.ts\` 9; the refactor keeps old tests green).
- \`npm run build\` → succeeds.
- Live browser check: DRD thumbnail renders, Edit opens the editable modeler (palette present), Close returns to the slide, and \`engine="camunda"\` mounts the properties panel — no component console errors.