### PR TITLE
feat: adopt documented portless dev setup and add Conductor scripts

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "npm install"
+run = "npm run dev"
+run_mode = "concurrent"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ This is a Slidev addon that enables displaying DMN (Decision Model and Notation)
 ## Development Commands
 
 ```bash
-# Run the example presentation in dev mode
+# Run the example presentation in dev mode (via portless — stable .localhost URL)
 npm run dev
+
+# Run the Slidev dev server directly, without portless
+npm run dev:app
 
 # Build the example presentation
 npm run build
@@ -20,6 +23,27 @@ npm run export
 
 # Export presentation to PNG screenshots
 npm run screenshot
+```
+
+### Dev server URLs (portless)
+
+`npm run dev` runs the Slidev server behind [portless](https://portless.sh), which is a
+pinned **devDependency** (no global install needed). portless replaces the dev port with a
+stable, git-worktree-aware URL: in the main checkout it serves
+`https://slidev-addon-dmn.localhost`, and in a linked git worktree it auto-derives
+`https://<worktree>.slidev-addon-dmn.localhost`. The slug is portless-derived — never
+hand-build it.
+
+Config lives in `portless.json` (`{ "name": "slidev-addon-dmn", "script": "dev:app" }`): `dev`
+is just the portless entrypoint, and the real Slidev command lives in `dev:app` so non-portless
+users can run the server directly. portless sets `$PORT`; Slidev binds to IPv4 via
+`--remote --bind 127.0.0.1` (its `localhost` default resolves to IPv6 `::1`, which portless
+can't proxy on macOS).
+
+**One-time per machine:** install the proxy daemon so it survives reboots (needs sudo once):
+
+```bash
+npx portless service install
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -152,7 +152,21 @@ In fullscreen mode, the panel can be hidden and shown again via the toolbar — 
 
 Contributions are welcome! Feel free to report bugs, suggest features via [issues](https://github.com/emaarco/slidev-addon-dmn/issues), submit pull requests with improvements, or share your ideas and use cases.
 
-To develop locally: clone the repo, run `npm install`, then `npm run dev` to test your changes.
+To develop locally: clone the repo and run `npm install`. The dev server runs behind
+[portless](https://portless.sh) (a pinned devDependency — no global install) for a stable,
+git-worktree-aware `.localhost` URL. Install the proxy daemon once per machine (needs sudo once):
+
+```bash
+npx portless service install
+```
+
+Then run the example presentation:
+
+```bash
+npm run dev        # via portless → https://slidev-addon-dmn.localhost
+                   # (in a git worktree → https://<worktree>.slidev-addon-dmn.localhost)
+npm run dev:app    # or run the Slidev server directly, without portless
+```
 
 ## 🙏 Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@vue/test-utils": "2.4.11",
         "jsdom": "29.1.1",
         "playwright-chromium": "1.61.0",
+        "portless": "0.15.0",
         "vitest": "4.1.9"
       },
       "engines": {
@@ -10956,6 +10957,24 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/portless": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.15.0.tgz",
+      "integrity": "sha512-GCrWz4GFPe4vbkGmDvXK78bGaKrVnIN2H6De3kAtoCfv1+CddaUaqPmA/hBzxQjGHbj+MpQMJEQ187tVqMtw2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Display DMN decision tables and DRD diagrams in Slidev presentations",
   "type": "module",
   "scripts": {
-    "dev": "portless run sh -c 'npx slidev example.md --port $PORT --remote --bind 127.0.0.1'",
+    "dev": "portless",
+    "dev:app": "slidev example.md --port $PORT --remote --bind 127.0.0.1",
     "build": "slidev build example.md",
     "export": "slidev export example.md",
     "screenshot": "slidev export example.md --format png",
@@ -27,6 +28,7 @@
     "@vue/test-utils": "2.4.11",
     "jsdom": "29.1.1",
     "playwright-chromium": "1.61.0",
+    "portless": "0.15.0",
     "vitest": "4.1.9"
   },
   "keywords": [

--- a/portless.json
+++ b/portless.json
@@ -1,0 +1,4 @@
+{
+  "name": "slidev-addon-dmn",
+  "script": "dev:app"
+}


### PR DESCRIPTION
## Summary

Adopts the **documented** [portless](https://portless.sh) dev setup (replacing the previous hand-rolled wrapper) for stable, git-worktree-aware `.localhost` dev URLs, and wires it into Conductor.

### Frontend (the only thing portless wraps)
- Add `portless` as an **exact-pinned devDependency** (`0.15.0`) — no global install; `npm install` is enough.
- Add `portless.json` (`{ "name": "slidev-addon-dmn", "script": "dev:app" }`).
- Split npm scripts so `dev` is just the portless entrypoint and the real command lives in `dev:app` (the `script: dev:app` config is what avoids recursion):
  - `"dev": "portless"`
  - `"dev:app": "slidev example.md --port $PORT --remote --bind 127.0.0.1"`
- Drop the hand-rolled `portless run sh -c '… $PORT …'` wrapper and the global-install assumption. `$PORT` now expands natively in the `dev:app` shell.
- `--remote --bind 127.0.0.1` forces Slidev to listen on IPv4 (its default `localhost` → IPv6 `::1`, which portless can't proxy on macOS). Verified Slidev has no `--host`; `--bind` only applies in `--remote` mode.

### Conductor
- Add committed `.conductor/settings.toml`: `setup = "npm install"`, `run = "npm run dev"`, `run_mode = "concurrent"`.
- `concurrent` is safe because each workspace is its own git worktree → portless auto-derives a distinct `<workspace>.slidev-addon-dmn.localhost` subdomain. No `CONDUCTOR_PORT` threading needed.

### Non-frontend components
None. This is a pure frontend Slidev addon library — no backend, DB, Docker, broker, or fixed ports — so nothing else needs per-workspace isolation.

### Docs
- README & CLAUDE.md updated: devDependency (no global), one-time `npx portless service install` (needs sudo once; required for the headless Run button), the `<worktree>.slidev-addon-dmn.localhost` URL shape (slug is portless-derived), and `npm run dev:app` to run Slidev without portless.

## Verification
- `node_modules/.bin/portless --version` → `0.15.0` (resolves locally).
- `portless.json` + `package.json` valid JSON; `.conductor/settings.toml` valid TOML.
- `npm run dev` → `portless` → reads `portless.json` → dispatches to `npm run dev:app` → Slidev boots at `https://<worktree>.slidev-addon-dmn.localhost` with `PORT`/`HOST=127.0.0.1`. **No recursion.**