### PR TITLE
fix: stop DmnTable rAF polling loop on unmount to prevent flaky tests

### DIFF
--- a/components/DmnTable.vue
+++ b/components/DmnTable.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import DmnViewer from 'dmn-js/lib/Viewer'
 import 'dmn-js/dist/assets/diagram-js.css'
 import 'dmn-js/dist/assets/dmn-js-shared.css'
@@ -29,6 +29,14 @@ import { useDmn } from '../composables/useDmn'
 const { loading, error, fetchDmnXml } = useDmn()
 const containerRef = ref<HTMLDivElement | null>(null)
 const isRendered = ref(false)
+const isUnmounted = ref(false)
+
+// Stop the container-polling loop once the component goes away, otherwise the
+// recursive requestAnimationFrame keeps rescheduling forever when the container
+// never gains dimensions (e.g. a slide that is never shown, or a jsdom test).
+onBeforeUnmount(() => {
+  isUnmounted.value = true
+})
 
 const props = withDefaults(defineProps<{
   dmnFilePath: string
@@ -53,7 +61,9 @@ const containerHeight = computed(() => props.height === 'auto' ? '500px' : props
 async function waitForContainer(): Promise<void> {
   return new Promise((resolve) => {
     const checkDimensions = () => {
-      if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
+      if (isUnmounted.value) {
+        resolve()
+      } else if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
         resolve()
       } else {
         requestAnimationFrame(checkDimensions)
@@ -77,6 +87,7 @@ async function renderDmnTable() {
 
   try {
     await waitForContainer()
+    if (isUnmounted.value) return
     const dmnXml = await fetchDmnXml(props.dmnFilePath)
     const viewer = new DmnViewer({
       container: containerRef.value!,

--- a/tests/components/DmnTable.test.ts
+++ b/tests/components/DmnTable.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { afterEach } from 'vitest'
+import { enableAutoUnmount, mount, flushPromises } from '@vue/test-utils'
+
+enableAutoUnmount(afterEach)
 
 const { mockImportXML, mockOpen, mockGetViews, MockDmnViewer } = vi.hoisted(() => ({
   mockImportXML: vi.fn(),


### PR DESCRIPTION
## Problem

CI (`npm test`) intermittently failed with two unhandled errors even though all 28 assertions passed:

```
ReferenceError: requestAnimationFrame is not defined
This error originated in "tests/components/DmnTable.test.ts"
```

Vitest exits non-zero on unhandled errors, so the pipeline went red on some runs and green on re-runs — a classic flake.

## Root cause

`DmnTable.vue`'s `waitForContainer()` runs a recursive `requestAnimationFrame` loop that only stops once the container reports non-zero dimensions. In tests, `requestAnimationFrame` is shimmed to `setTimeout(cb, 0)`. Several tests mount `DmnTable` without ever giving the container dimensions, so the loop **never resolves and reschedules timers forever**. Those pending timers outlive the test file; when Vitest tears down the jsdom environment between files, a queued callback calls the now-undefined `requestAnimationFrame`. Whether it fires before or after teardown is a race → flaky.

This is also a latent production bug: a `DmnTable` on a slide that never becomes visible (container stays 0×0) would spin rAF indefinitely.

## Fix

- `components/DmnTable.vue`: add an `isUnmounted` flag set in `onBeforeUnmount`; the polling loop bails when unmounted and `renderDmnTable` returns early after the await.
- `tests/components/DmnTable.test.ts`: `enableAutoUnmount(afterEach)` so every mounted component is torn down after each test, actually stopping the loop.

## Verification

- Full suite green: 3 files, 28 tests pass, exit 0.
- Ran the `DmnTable` suite 5× in a row — no unhandled errors, all exit 0 (was intermittently failing before).