### PR TITLE
chore: switch dependabot to balanced grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,44 @@
 version: 2
 updates:
-  # Config for npm dependencies
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 5
     labels:
       - "dependencies"
-    assignees:
-      - "emaarco"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
     groups:
-      dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-          - "major"
-    open-pull-requests-limit: 2
+      npm-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
 
-  # Config for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 5
     labels:
       - "dependencies"
-    assignees:
-      - "emaarco"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
-          - "minor"
-          - "major"
-    open-pull-requests-limit: 2
+        applies-to: version-updates
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## What

Repairs `.github/dependabot.yml` for this **published open-source npm library**, moving it from a low-noise config (all update types grouped into one PR per ecosystem) to a **balanced** config.

## Changes

- **npm majors split out** — `minor`+`patch` stay grouped (`npm-minor-patch`); each **major now lands as its own PR** so breaking changes get individual review before this library republishes.
- **Security-update groups added** — `npm-security` + `github-actions-security` (`applies-to: security-updates`) consolidate CVE PRs instead of one per advisory.
- **PR limit raised** — `open-pull-requests-limit` 2 → 10 to leave headroom for individual major PRs.
- **npm cooldown made semver-aware** — major 14d / minor 5d / patch 3d so fresh majors mature longer (security fixes are never delayed by cooldown).
- **github-actions kept fully grouped, monthly** — actions are SHA-pinned and CI gates every PR, so action majors are mostly mechanical.
- **Dropped redundant `assignees: emaarco`** — the existing `.github/CODEOWNERS` (`* @emaarco`) already requests review on every PR.

## Notes

- Pin gate passed: all npm deps are exact-pinned (lockfile committed, `Miragon/pin-npm-dependencies` guard) and every action `uses:` is SHA-pinned.
- Dependabot commits now use the `chore(deps):` prefix (was `build(deps):`); both are valid conventional-commit types, so `pr-title.yml` and release-please stay compatible — the changelog category shifts from Build to Chore.
- Created the `dependencies` repo label; CODEOWNERS validated with 0 errors.