### PR TITLE
feat: add showDrdButton prop to toggle the "View DRD" button in DmnTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 | `decisionId` | `string` | *first found* | ID of the decision to display (optional, defaults to the first decision table) |
 | `fontSize` | `string` | `'12px'` | Font size of the table content |
 | `showAnnotations` | `boolean` | `false` | Show or hide the annotations column |
+| `showDrdButton` | `boolean` | `false` | Show or hide the built-in "View DRD" button |
 
 ### DmnModeler Component
 

--- a/components/DmnTable.vue
+++ b/components/DmnTable.vue
@@ -4,7 +4,7 @@
     <p v-else-if="error" class="text-red-500">{{ error }}</p>
     <div ref="containerRef"
          class="dmn-table-wrapper"
-         :class="{ 'hide-annotations': !props.showAnnotations }"
+         :class="{ 'hide-annotations': !props.showAnnotations, 'hide-drd-button': !props.showDrdButton }"
          :style="{
            width: `calc(${props.width} - ${5 * 2}px)`,
            height: `calc(${containerHeight} - ${5 * 2}px)`,
@@ -45,11 +45,13 @@ const props = withDefaults(defineProps<{
   decisionId?: string
   fontSize?: string
   showAnnotations?: boolean
+  showDrdButton?: boolean
 }>(), {
   width: '100%',
   height: 'auto',
   fontSize: '12px',
   showAnnotations: false,
+  showDrdButton: false,
 })
 
 const containerHeight = computed(() => props.height === 'auto' ? '500px' : props.height)
@@ -198,6 +200,11 @@ onSlideEnter(async () => {
 /* Hide annotations column when toggled off */
 .dmn-table-wrapper.hide-annotations th.annotation,
 .dmn-table-wrapper.hide-annotations td.annotation {
+  display: none !important;
+}
+
+/* Hide the "View DRD" button when toggled off */
+.dmn-table-wrapper.hide-drd-button .view-drd {
   display: none !important;
 }
 </style>

--- a/tests/components/DmnTable.test.ts
+++ b/tests/components/DmnTable.test.ts
@@ -187,4 +187,18 @@ describe('DmnTable.vue', () => {
 
     expect(mockOpen).toHaveBeenCalledWith(TABLE_VIEW)
   })
+
+  it('hides the "View DRD" button by default', () => {
+    mockFetchSuccess()
+    const wrapper = mount(DmnTable, { props: { dmnFilePath: 'test.dmn' } })
+    expect(wrapper.find('div.dmn-table-wrapper').classes()).toContain('hide-drd-button')
+  })
+
+  it('keeps the "View DRD" button when showDrdButton is true', () => {
+    mockFetchSuccess()
+    const wrapper = mount(DmnTable, {
+      props: { dmnFilePath: 'test.dmn', showDrdButton: true },
+    })
+    expect(wrapper.find('div.dmn-table-wrapper').classes()).not.toContain('hide-drd-button')
+  })
 })


### PR DESCRIPTION
## What

Adds a `showDrdButton` prop to the `DmnTable` component to control the built-in dmn-js **"View DRD"** button. It defaults to `false`, so the button is **hidden by default**.

## Why

When embedding a decision table in a slide, the "View DRD" button is usually undesired visual clutter. This makes it opt-in.

## How

- New prop `showDrdButton?: boolean` (default `false`).
- Toggles a `hide-drd-button` class on the wrapper, which hides dmn-js's `.view-drd` container via CSS — mirroring the existing `showAnnotations` pattern.
- README props table updated.

## Usage

```vue
<!-- default: button hidden -->
<DmnTable dmnFilePath="/example.dmn" />

<!-- opt in to show the button -->
<DmnTable dmnFilePath="/example.dmn" :showDrdButton="true" />
```

## Tests

Added two unit tests asserting the class binding (hidden by default, shown when enabled). Full suite passes (12/12).

> Note: dmn-js is mocked in the unit tests, so the tests cover our class-toggle logic; the actual visual hiding is CSS over dmn-js internals.