### PR TITLE
feat: add DmnSimulate component for live decision evaluation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,13 @@ npx portless service install
 
 ### Core Components
 
-The addon consists of three Vue components, backed by shared helpers in `composables/`
+The addon consists of four Vue components, backed by shared helpers in `composables/`
 (`useDmn.ts` — fetch + loading/error state), `shared/` (`ui/ToolbarButton.vue`,
-`lib/fitDiagram.ts`) and `engines/` (`camunda.ts` — properties-panel config). The
+`lib/fitDiagram.ts`, and the simulation stack: `lib/dmnModel.ts` — DMN XML → model,
+`lib/feel.ts` — `feelin` adapter, `lib/hitPolicy.ts` — pure hit-policy semantics,
+`lib/evaluateDecision.ts` — orchestrator wiring the three together) and `engines/`
+(`camunda.ts` — properties-panel config). Each `shared/lib` module has a 1:1 test in
+`tests/lib/`. The
 `composables/`, `shared/` and `engines/` directories are published to npm alongside
 `components/`.
 
@@ -73,6 +77,14 @@ dependency-cruiser (`npm run lint:deps`, config in `.dependency-cruiser.cjs`).
 2. **Renders using dmn-js**: Attaches the viewer directly to a container in the DOM
 3. **Opens decision table view**: Navigates to the specified decision table (or first found)
 4. **Dual lifecycle**: Uses both `onMounted` and `onSlideEnter` for PDF export and live preview compatibility
+
+#### `components/DmnSimulate.vue`
+1. **Fetches + parses DMN XML**: Loads the `.dmn` file, then parses the decision table into a plain model (`shared/lib/dmnModel.ts`) — inputs, outputs, rules and hit policy
+2. **Renders the table**: Same in-DOM `dmn-js/lib/Viewer` approach as `DmnTable`
+3. **Input form**: One control per input (dropdown for string columns with literal values, number/text field otherwise), derived from the parsed model
+4. **Evaluates with FEEL**: On "Simulate", runs each rule's unary tests via the `feelin` engine (`shared/lib/evaluateDecision.ts`) — this is the DMN analogue of BPMN token simulation (DMN is declarative, so "simulation" = evaluate inputs → which rule fires)
+5. **Applies the hit policy**: `shared/lib/hitPolicy.ts` implements the full DMN set — UNIQUE, ANY, PRIORITY, FIRST, COLLECT (with SUM/MIN/MAX/COUNT aggregation), RULE ORDER, OUTPUT ORDER. No JS/browser DMN engine covers this set (`dmn-eval-js` and forks are unmaintained since 2022 and lack PRIORITY/OUTPUT ORDER/aggregation), so the table-orchestration layer is owned here on top of `feelin` (accessed via `shared/lib/feel.ts`, which handles only FEEL expressions/unary tests). PRIORITY/OUTPUT ORDER rank by the output's `<outputValues>` list; UNIQUE/ANY flag a `violation`
+6. **Highlights the result**: reported rule(s) get a strong `sim-match` class, rules that matched but were dropped by the policy get a faint `sim-candidate` class (mapped by rule index → row order); shows the output(s), an aggregate, or a violation badge. One demo slide per policy lives in `example.md` (`public/hit-policies/*.dmn`)
 
 #### `components/DmnModeler.vue`
 1. **Thumbnail viewer**: Renders a read-only DRD preview in the slide (`dmn-js/lib/Viewer`), fit via `fitDiagram`
@@ -97,7 +109,7 @@ The `vite.config.ts` file is **critical** for this addon to work. It includes dm
 ## Package Distribution
 
 The npm package includes only:
-- `components/` directory (DmnDrd.vue, DmnTable.vue, DmnModeler.vue)
+- `components/` directory (DmnDrd.vue, DmnTable.vue, DmnSimulate.vue, DmnModeler.vue)
 - `composables/`, `shared/`, `engines/` directories (shared helpers used by the components)
 - `vite.config.ts` (required Vite configuration)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Powered by [dmn-js](https://bpmn.io/toolkit/dmn-js/) from bpmn.io.
 
 1. Install the addon in your Slidev project
 2. Place your `.dmn` files in the `public/` folder
-3. Use the `<DmnDrd>`, `<DmnTable>` or `<DmnModeler>` components in your slides
+3. Use the `<DmnDrd>`, `<DmnTable>`, `<DmnSimulate>` or `<DmnModeler>` components in your slides
 
 That's it — your DMN diagrams are ready to present!
 
@@ -47,10 +47,11 @@ Or in your `package.json`:
 
 ## 🧩 Components
 
-This addon provides three complementary components for different use cases:
+This addon provides four complementary components for different use cases:
 
 - **`<DmnDrd>`** - Static DRD rendering for PDFs, presentations, and documentation
 - **`<DmnTable>`** - Decision Table rendering for visualizing business rules
+- **`<DmnSimulate>`** - Decision Table with an input form: evaluate the decision live and highlight the matching rule (DMN's answer to BPMN token simulation)
 - **`<DmnModeler>`** - Interactive DMN modeler for live editing during workshops and trainings, with an optional Camunda properties panel
 
 ## 🔧 Component Reference
@@ -99,6 +100,34 @@ Renders DMN Decision Tables directly in the slide. Perfect for presenting busine
 | `fontSize` | `string` | `'12px'` | Font size of the table content |
 | `showAnnotations` | `boolean` | `false` | Show or hide the annotations column |
 | `showDrdButton` | `boolean` | `false` | Show or hide the built-in "View DRD" button |
+
+### DmnSimulate Component
+
+Renders a Decision Table together with an input form and evaluates it live. Pick the inputs, hit **Simulate**, and the matching rule row is highlighted while the resulting output is shown below the table. Because DMN is declarative (no wandering token like BPMN), this is the DMN equivalent of a token simulation: feed inputs in, watch which rule fires. FEEL expressions are evaluated with the [feelin](https://github.com/nikku/feelin) engine.
+
+```vue
+<DmnSimulate
+  dmnFilePath="./my-decisions.dmn"
+  width="100%"
+  height="340px"
+/>
+```
+
+**Props:**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `dmnFilePath` | `string` | *required* | Path to the `.dmn` file (relative to `public/`) |
+| `width` | `string` | `'100%'` | Width of the container |
+| `height` | `string` | `'340px'` | Height of the decision table |
+| `decisionId` | `string` | *first found* | ID of the decision to simulate (defaults to the first decision table) |
+| `fontSize` | `string` | `'12px'` | Font size of the table content |
+| `showAnnotations` | `boolean` | `false` | Show or hide the annotations column |
+| `showDrdButton` | `boolean` | `false` | Show or hide the built-in "View DRD" button |
+
+> **Hit policies:** the full DMN set is supported — `UNIQUE`, `ANY`, `PRIORITY`, `FIRST`, `COLLECT` (incl. `SUM`/`MIN`/`MAX`/`COUNT` aggregation), `RULE ORDER` and `OUTPUT ORDER`. The rule(s) the policy actually reports are highlighted strongly; rules that merely matched but were dropped (e.g. under `FIRST`/`PRIORITY`) are shown as faint candidates. `PRIORITY` and `OUTPUT ORDER` use the output's `<outputValues>` list as the priority order. `UNIQUE`/`ANY` show a violation badge when their constraint is broken. Input cells are evaluated as FEEL unary tests via [feelin](https://github.com/nikku/feelin); an empty cell matches any value.
+>
+> The [`example.md`](./example.md) deck includes one slide per hit policy (`public/hit-policies/*.dmn`) demonstrating each behaviour live.
 
 ### DmnModeler Component
 

--- a/components/DmnSimulate.vue
+++ b/components/DmnSimulate.vue
@@ -1,0 +1,443 @@
+<template>
+  <div class="dmn-simulate" :style="{ width: props.width }">
+    <p v-if="loading">Loading DMN decision table...</p>
+    <p v-else-if="error" class="text-red-500">{{ error }}</p>
+
+    <!-- Input form: one control per decision-table input -->
+    <form v-if="model" class="sim-inputs" @submit.prevent="runSimulation">
+      <div v-for="(input, i) in model.inputs" :key="input.id" class="sim-field">
+        <label>{{ input.label }}</label>
+        <select v-if="input.options.length" v-model="values[i]">
+          <option value="">–</option>
+          <option v-for="option in input.options" :key="option" :value="option">{{ option }}</option>
+        </select>
+        <input
+          v-else
+          v-model="values[i]"
+          :type="isNumericType(input.typeRef) ? 'number' : 'text'"
+          :placeholder="input.typeRef"
+        />
+      </div>
+      <button
+        type="submit"
+        class="sim-run"
+        :disabled="!isComplete"
+        :title="isComplete ? 'Run the simulation' : 'Fill in every input first'"
+      >Simulate</button>
+      <button type="button" class="sim-reset" @click="reset">Reset</button>
+    </form>
+
+    <!-- The decision table, rendered by dmn-js -->
+    <div
+      ref="containerRef"
+      class="dmn-table-wrapper"
+      :class="{ 'hide-annotations': !props.showAnnotations, 'hide-drd-button': !props.showDrdButton }"
+      :style="{
+        width: `calc(${props.width} - ${5 * 2}px)`,
+        height: props.height,
+        margin: `5px`,
+        '--dmn-table-font-size': props.fontSize,
+      }"
+    ></div>
+
+    <!-- Result of the last simulation -->
+    <div
+      v-if="result"
+      class="sim-result"
+      :class="{ 'sim-result--miss': !result.matchedRuleIndices.length, 'sim-result--warn': !!result.violation }"
+    >
+      <span class="sim-arrow">→</span>
+
+      <!-- COLLECT with an aggregation collapses to a single scalar -->
+      <span v-if="result.aggregation" class="sim-output">
+        {{ result.aggregation.fn }}({{ result.aggregation.output }}) =
+        <strong>{{ result.aggregation.value }}</strong>
+      </span>
+
+      <!-- One pill per reported output row (list policies show several) -->
+      <template v-else-if="result.outputs.length">
+        <span v-for="(output, oi) in result.outputs" :key="oi" class="sim-output">
+          <template v-for="(value, key) in output" :key="key">
+            {{ key }} = <strong>{{ formatValue(value) }}</strong>
+          </template>
+        </span>
+      </template>
+
+      <span v-else class="sim-none">no matching rule</span>
+
+      <span v-if="result.violation" class="sim-violation">⚠ {{ result.violation }}</span>
+
+      <span v-if="result.reportedRuleIndices.length" class="sim-rule">
+        {{ result.reportedRuleIndices.length > 1 ? 'Rules' : 'Rule' }}
+        {{ result.reportedRuleIndices.map(i => i + 1).join(', ') }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import DmnViewer from 'dmn-js/lib/Viewer'
+import 'dmn-js/dist/assets/diagram-js.css'
+import 'dmn-js/dist/assets/dmn-js-shared.css'
+import 'dmn-js/dist/assets/dmn-js-decision-table.css'
+import 'dmn-js/dist/assets/dmn-js-decision-table-controls.css'
+import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css'
+import { onSlideEnter } from '@slidev/client'
+import { useDmn } from '../composables/useDmn'
+import { isNumericType, parseDecisionModel, type DecisionModel } from '../shared/lib/dmnModel'
+import { evaluateDecision, type EvaluationResult, type RawValue } from '../shared/lib/evaluateDecision'
+
+const props = withDefaults(defineProps<{
+  dmnFilePath: string
+  width?: string
+  height?: string
+  decisionId?: string
+  fontSize?: string
+  showAnnotations?: boolean
+  showDrdButton?: boolean
+}>(), {
+  width: '100%',
+  height: '340px',
+  fontSize: '12px',
+  showAnnotations: false,
+  showDrdButton: false,
+})
+
+const { loading, error, fetchDmnXml } = useDmn()
+const containerRef = ref<HTMLDivElement | null>(null)
+const model = ref<DecisionModel | null>(null)
+const values = ref<RawValue[]>([])
+const result = ref<EvaluationResult | null>(null)
+const isRendered = ref(false)
+const isUnmounted = ref(false)
+
+// Only allow simulating once every input has a value — an incomplete input set
+// can never match a concrete rule, so the button stays disabled until then.
+const isComplete = computed(() =>
+  !!model.value
+  && model.value.inputs.length > 0
+  && values.value.length === model.value.inputs.length
+  && values.value.every(v => v !== '' && v !== null && v !== undefined),
+)
+
+onBeforeUnmount(() => {
+  isUnmounted.value = true
+})
+
+// Any input change invalidates the previous run — clear the result + highlight
+// so the table never shows a stale match next to fresh inputs.
+watch(values, () => {
+  if (result.value) {
+    result.value = null
+    applyHighlight([], [])
+  }
+}, { deep: true })
+
+async function waitForContainer(): Promise<void> {
+  return new Promise((resolve) => {
+    const checkDimensions = () => {
+      if (isUnmounted.value) {
+        resolve()
+      } else if (containerRef.value && containerRef.value.clientWidth > 0 && containerRef.value.clientHeight > 0) {
+        resolve()
+      } else {
+        requestAnimationFrame(checkDimensions)
+      }
+    }
+    checkDimensions()
+  })
+}
+
+/**
+ * Fetch the DMN once, parse it into a simulation model, then render the table
+ * via dmn-js. Guarded against the duplicate onMounted/onSlideEnter calls Slidev
+ * makes (mirrors DmnTable).
+ */
+async function setup() {
+  if (isRendered.value) return
+  isRendered.value = true
+  loading.value = true
+  error.value = null
+
+  try {
+    await waitForContainer()
+    if (isUnmounted.value) return
+
+    const dmnXml = await fetchDmnXml(props.dmnFilePath)
+    model.value = parseDecisionModel(dmnXml, props.decisionId)
+    values.value = model.value.inputs.map(() => '')
+
+    // Let the container mount before dmn-js measures it.
+    await nextTick()
+
+    const viewer = new DmnViewer({ container: containerRef.value! })
+    await viewer.importXML(dmnXml)
+
+    const views = viewer.getViews()
+    const tableView = props.decisionId
+      ? views.find((v: any) => v.type === 'decisionTable' && v.element?.id === props.decisionId)
+      : views.find((v: any) => v.type === 'decisionTable')
+    if (!tableView) {
+      throw new Error('No decision table view found in DMN file')
+    }
+    await viewer.open(tableView)
+  } catch (err) {
+    isRendered.value = false
+    model.value = null
+    error.value = `Failed to load DMN: ${err instanceof Error ? err.message : String(err)}`
+    console.error('DMN loading error:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function runSimulation() {
+  if (!model.value || !isComplete.value) return
+  const evaluation = evaluateDecision(model.value, values.value)
+  result.value = evaluation
+  applyHighlight(evaluation.reportedRuleIndices, evaluation.matchedRuleIndices)
+}
+
+function reset() {
+  if (model.value) values.value = model.value.inputs.map(() => '')
+  result.value = null
+  applyHighlight([], [])
+}
+
+/**
+ * Highlight rules directly in the dmn-js DOM. Rows render in document order, so
+ * rule index N maps to the Nth `<tbody>` row. Rules the hit policy actually
+ * reports get the strong `sim-match` style; rules that merely matched but were
+ * dropped by the policy (e.g. under FIRST/PRIORITY) get the subtle
+ * `sim-candidate` style, making the policy's effect visible.
+ */
+function applyHighlight(reported: number[], matched: number[]) {
+  const rows = containerRef.value?.querySelectorAll('.dmn-decision-table-container tbody tr') ?? []
+  rows.forEach((row, i) => {
+    row.classList.toggle('sim-match', reported.includes(i))
+    row.classList.toggle('sim-candidate', matched.includes(i) && !reported.includes(i))
+  })
+
+  // The table scrolls internally when it is taller than the slide allows, so a
+  // matched rule below the fold would stay hidden — scroll the first relevant
+  // row into the visible band of the table's own scroll container (never the page).
+  const focusIndex = reported[0] ?? matched[0]
+  if (focusIndex === undefined) return
+  const firstRow = rows[focusIndex] as HTMLElement | undefined
+  const scroller = containerRef.value?.querySelector('.tjs-table-container') as HTMLElement | null
+  if (!firstRow || !scroller) return
+  const rowRect = firstRow.getBoundingClientRect()
+  const scrollRect = scroller.getBoundingClientRect()
+  if (rowRect.top < scrollRect.top || rowRect.bottom > scrollRect.bottom) {
+    scroller.scrollTop += (rowRect.top - scrollRect.top) - (scrollRect.height - rowRect.height) / 2
+  }
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '–'
+  if (typeof value === 'string') return value
+  return JSON.stringify(value)
+}
+
+onMounted(async () => {
+  await nextTick()
+  await setup()
+})
+
+onSlideEnter(async () => {
+  await setup()
+})
+</script>
+
+<style>
+.dmn-simulate {
+  display: flex;
+  flex-direction: column;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* --- Simulation input form --- */
+.dmn-simulate .sim-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 8px 5px;
+}
+
+.dmn-simulate .sim-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dmn-simulate .sim-field label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #555;
+}
+
+.dmn-simulate .sim-field input,
+.dmn-simulate .sim-field select {
+  font-size: 13px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  min-width: 120px;
+}
+
+.dmn-simulate .sim-run,
+.dmn-simulate .sim-reset {
+  font-size: 13px;
+  padding: 5px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+
+.dmn-simulate .sim-run {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: white;
+  font-weight: 600;
+}
+
+.dmn-simulate .sim-run:disabled {
+  background: #cbd5e1;
+  border-color: #cbd5e1;
+  color: #eef2f7;
+  cursor: not-allowed;
+}
+
+.dmn-simulate .sim-reset {
+  background: white;
+  color: #555;
+}
+
+/* --- Simulation result line --- */
+.dmn-simulate .sim-result {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 10px;
+  margin: 5px;
+  font-size: 14px;
+  background: #ecfdf5;
+  border: 1px solid #a7f3d0;
+  border-radius: 6px;
+  color: #065f46;
+}
+
+.dmn-simulate .sim-result--miss {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.dmn-simulate .sim-result--warn {
+  background: #fffbeb;
+  border-color: #fde68a;
+  color: #92400e;
+}
+
+.dmn-simulate .sim-arrow {
+  font-weight: 700;
+}
+
+/* Each reported output row as a pill — several appear for list policies. */
+.dmn-simulate .sim-output {
+  padding: 1px 6px;
+  background: rgba(6, 95, 70, 0.08);
+  border-radius: 4px;
+}
+
+.dmn-simulate .sim-violation {
+  flex-basis: 100%;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.dmn-simulate .sim-rule {
+  margin-left: auto;
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+/* --- Highlight rows in the dmn-js table --- */
+/* Reported rule(s): the actual result of the hit policy. */
+.dmn-simulate .dmn-decision-table-container tbody tr.sim-match td {
+  background: #fef9c3 !important;
+  box-shadow: inset 0 0 0 9999px rgba(250, 204, 21, 0.18);
+}
+
+/* Candidate rule(s): matched, but dropped by the policy (e.g. FIRST/PRIORITY). */
+.dmn-simulate .dmn-decision-table-container tbody tr.sim-candidate td {
+  background: #f1f5f9 !important;
+  box-shadow: inset 0 0 0 9999px rgba(148, 163, 184, 0.14);
+}
+
+/* --- Table styling (mirrors DmnTable so DmnSimulate stands alone) --- */
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container {
+  font-size: var(--dmn-table-font-size, 12px) !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container .decision-table-name {
+  font-size: calc(var(--dmn-table-font-size, 12px) * 1.5) !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .tjs-container {
+  width: 100% !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .tjs-table-container {
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .tjs-table {
+  width: 100% !important;
+  table-layout: fixed !important;
+}
+
+.dmn-simulate .dmn-table-wrapper th:not(:first-child),
+.dmn-simulate .dmn-table-wrapper td:not(:first-child) {
+  padding: 2px !important;
+}
+
+.dmn-simulate .dmn-table-wrapper th.index-column {
+  width: 36px !important;
+}
+
+.dmn-simulate .dmn-table-wrapper.hide-annotations th.annotation,
+.dmn-simulate .dmn-table-wrapper.hide-annotations td.annotation {
+  display: none !important;
+}
+
+.dmn-simulate .dmn-table-wrapper.hide-drd-button .view-drd {
+  display: none !important;
+}
+
+/* --- Pin the bpmn.io watermark to a consistent spot ---
+   dmn-js anchors its (license-required) logo to the decision-table container,
+   whose height tracks the row count — so the logo floats below short tables but
+   overlaps the last row of tall ones. Re-anchor it to the fixed-height wrapper
+   so it always sits in the same bottom-right corner. The logo stays fully
+   visible and clickable, as the bpmn.io license requires. */
+.dmn-simulate .dmn-table-wrapper {
+  position: relative;
+}
+
+.dmn-simulate .dmn-table-wrapper .dmn-js-parent,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container,
+.dmn-simulate .dmn-table-wrapper .tjs-container {
+  position: static !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .bjs-powered-by {
+  bottom: 6px !important;
+  right: 8px !important;
+}
+</style>

--- a/components/README.md
+++ b/components/README.md
@@ -8,6 +8,7 @@ any `.md` slide **without an import**:
 ```md
 <DmnDrd dmnFilePath="/example.dmn" />
 <DmnTable dmnFilePath="/example.dmn" />
+<DmnSimulate dmnFilePath="/example.dmn" />
 <DmnModeler engine="camunda" />
 ```
 
@@ -30,4 +31,5 @@ end users should mount it directly.
 |---|---|
 | `DmnDrd.vue` | Static SVG rendering of the DRD (off-screen render, best for PDF export) |
 | `DmnTable.vue` | Renders a DMN decision table directly in the DOM |
+| `DmnSimulate.vue` | Renders a decision table with an input form; evaluates it with FEEL and highlights the matched rule (DMN's answer to BPMN token simulation) |
 | `DmnModeler.vue` | Live DMN modeler; optional `engine` prop mounts a properties panel |

--- a/example.md
+++ b/example.md
@@ -11,6 +11,7 @@ No manual export chaos, just saubere decision diagrams!
 **Features:**
 - Static DRD rendering for PDFs and presentations
 - Decision Table rendering for rule visualization
+- Live decision simulation – evaluate inputs and watch the matching rule fire
 - Live DMN modeling for workshops and trainings
 
 ---
@@ -36,6 +37,78 @@ The `DmnTable` component renders Decision Tables directly – the rules laid out
 The `DmnModeler` component embeds an editable diagram – hit **Edit** and the DMN opens fullscreen. Tweak the DRD, double-click the **Dish** decision to edit its table live, then **Close** and the slide reflects your changes. Ideal for workshops where you build decisions together with your audience!
 
 <DmnModeler dmnFilePath="./example.dmn" height="350px"></DmnModeler>
+
+---
+
+## Decision Simulation
+
+The `DmnSimulate` component makes a table a **live decision** – pick the inputs, hit **Simulate**, the matching rule lights up. DMN's answer to BPMN token simulation: feed inputs in, watch the rule fire.
+
+<DmnSimulate dmnFilePath="./example.dmn" height="305px" fontSize="10px"></DmnSimulate>
+
+---
+
+## Hit Policy: UNIQUE
+
+**UNIQUE** – at most one rule may match. The ranges don't overlap, so a `Spend` picks exactly one tier (try `3000` → Silver). If two rules ever matched, you'd get a violation warning.
+
+<DmnSimulate dmnFilePath="./hit-policies/unique.dmn" height="240px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: FIRST
+
+**FIRST** – rules overlap, the first match wins. Try `OrderTotal = 600`: all three rules match, but only **20 %** fires – the rows below stay greyed-out candidates.
+
+<DmnSimulate dmnFilePath="./hit-policies/first.dmn" height="240px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: PRIORITY
+
+**PRIORITY** – overlapping rules, but the output with the highest priority wins (order: Decline ▸ Review ▸ Approve). `Score = 550` matches all three, yet **Decline** wins – not the first row.
+
+<DmnSimulate dmnFilePath="./hit-policies/priority.dmn" height="240px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: ANY
+
+**ANY** – several rules may match, as long as they agree. `Age = 25` matches both rules and both say **Granted**, so you get one clean result. Differing outputs would raise a violation.
+
+<DmnSimulate dmnFilePath="./hit-policies/any.dmn" height="230px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: COLLECT
+
+**COLLECT** – gather *all* matching outputs as a list. `Cart = 250` collects every applicable promotion.
+
+<DmnSimulate dmnFilePath="./hit-policies/collect.dmn" height="240px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: COLLECT + SUM
+
+**COLLECT** with an aggregation collapses the matches into one number. `Cart = 250` sums the loyalty points (5 + 10 + 20 = **35**). `MIN`, `MAX` and `COUNT` work the same way.
+
+<DmnSimulate dmnFilePath="./hit-policies/collect-sum.dmn" height="240px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: RULE ORDER
+
+**RULE ORDER** – like COLLECT, but the list keeps the table's rule order. `Temp = 40` → [Heat, Extreme Heat].
+
+<DmnSimulate dmnFilePath="./hit-policies/rule-order.dmn" height="230px" fontSize="11px"></DmnSimulate>
+
+---
+
+## Hit Policy: OUTPUT ORDER
+
+**OUTPUT ORDER** – all matches, sorted by output priority (Extreme Heat ▸ Heat). Same input as RULE ORDER, but the order flips: `Temp = 40` → [Extreme Heat, Heat].
+
+<DmnSimulate dmnFilePath="./hit-policies/output-order.dmn" height="230px" fontSize="11px"></DmnSimulate>
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@bpmn-io/properties-panel": "3.47.0",
         "camunda-dmn-moddle": "1.3.1",
         "dmn-js": "17.10.0",
-        "dmn-js-properties-panel": "3.11.1"
+        "dmn-js-properties-panel": "3.11.1",
+        "feelin": "7.0.1"
       },
       "devDependencies": {
         "@slidev/cli": "52.18.0",
@@ -9241,6 +9242,21 @@
         }
       }
     },
+    "node_modules/feelin": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/feelin/-/feelin-7.0.1.tgz",
+      "integrity": "sha512-P7jSNHxMfDMW7zojApEUClEOugv/J7UZEVvSG4Cuyzwxh1QiB1XXgBREkEEamdy3igHHzm+20lv0Mt3pws3teA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.2",
+        "lezer-feel": "^3.0.1",
+        "luxon": "^3.7.2",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/file-saver": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
@@ -10584,6 +10600,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-tTOBq2ZOwfekNXg7eflg9WK/jl4LW4pryR3wiGRp1/ODXBG3ngo2mqXcriULylTjdxCnz42ByMMFEgbOK0L7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -10919,6 +10949,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@bpmn-io/properties-panel": "3.47.0",
     "camunda-dmn-moddle": "1.3.1",
     "dmn-js": "17.10.0",
-    "dmn-js-properties-panel": "3.11.1"
+    "dmn-js-properties-panel": "3.11.1",
+    "feelin": "7.0.1"
   },
   "devDependencies": {
     "@slidev/cli": "52.18.0",

--- a/public/hit-policies/any.dmn
+++ b/public/hit-policies/any.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_Any" name="Any" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Access" name="Access Check">
+    <decisionTable id="DT_Any" hitPolicy="ANY">
+      <input id="in_age" label="Age">
+        <inputExpression id="ie_age" typeRef="integer"><text>Age</text></inputExpression>
+      </input>
+      <output id="out_access" label="Access" name="Access" typeRef="string" />
+      <rule id="a1">
+        <inputEntry id="a1i"><text>&gt;= 18</text></inputEntry>
+        <outputEntry id="a1o"><text>"Granted"</text></outputEntry>
+      </rule>
+      <rule id="a2">
+        <inputEntry id="a2i"><text>&gt;= 21</text></inputEntry>
+        <outputEntry id="a2o"><text>"Granted"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/collect-sum.dmn
+++ b/public/hit-policies/collect-sum.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_CollectSum" name="CollectSum" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Points" name="Loyalty Points">
+    <decisionTable id="DT_CollectSum" hitPolicy="COLLECT" aggregation="SUM">
+      <input id="in_cart" label="Cart Value (€)">
+        <inputExpression id="ie_cart" typeRef="integer"><text>Cart</text></inputExpression>
+      </input>
+      <output id="out_points" label="Points" name="Points" typeRef="integer" />
+      <rule id="s1">
+        <inputEntry id="s1i"><text>&gt;= 50</text></inputEntry>
+        <outputEntry id="s1o"><text>5</text></outputEntry>
+      </rule>
+      <rule id="s2">
+        <inputEntry id="s2i"><text>&gt;= 100</text></inputEntry>
+        <outputEntry id="s2o"><text>10</text></outputEntry>
+      </rule>
+      <rule id="s3">
+        <inputEntry id="s3i"><text>&gt;= 200</text></inputEntry>
+        <outputEntry id="s3o"><text>20</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/collect.dmn
+++ b/public/hit-policies/collect.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_Collect" name="Collect" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Promos" name="Applicable Promotions">
+    <decisionTable id="DT_Collect" hitPolicy="COLLECT">
+      <input id="in_cart" label="Cart Value (€)">
+        <inputExpression id="ie_cart" typeRef="integer"><text>Cart</text></inputExpression>
+      </input>
+      <output id="out_promo" label="Promotion" name="Promotion" typeRef="string" />
+      <rule id="c1">
+        <inputEntry id="c1i"><text>&gt;= 50</text></inputEntry>
+        <outputEntry id="c1o"><text>"Free Shipping"</text></outputEntry>
+      </rule>
+      <rule id="c2">
+        <inputEntry id="c2i"><text>&gt;= 100</text></inputEntry>
+        <outputEntry id="c2o"><text>"Gift Wrap"</text></outputEntry>
+      </rule>
+      <rule id="c3">
+        <inputEntry id="c3i"><text>&gt;= 200</text></inputEntry>
+        <outputEntry id="c3o"><text>"10% Voucher"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/first.dmn
+++ b/public/hit-policies/first.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_First" name="First" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Discount" name="Order Discount">
+    <decisionTable id="DT_First" hitPolicy="FIRST">
+      <input id="in_total" label="Order Total (€)">
+        <inputExpression id="ie_total" typeRef="integer"><text>OrderTotal</text></inputExpression>
+      </input>
+      <output id="out_discount" label="Discount" name="Discount" typeRef="string" />
+      <rule id="f1">
+        <inputEntry id="f1i"><text>&gt;= 500</text></inputEntry>
+        <outputEntry id="f1o"><text>"20%"</text></outputEntry>
+      </rule>
+      <rule id="f2">
+        <inputEntry id="f2i"><text>&gt;= 200</text></inputEntry>
+        <outputEntry id="f2o"><text>"10%"</text></outputEntry>
+      </rule>
+      <rule id="f3">
+        <inputEntry id="f3i"><text>&gt;= 0</text></inputEntry>
+        <outputEntry id="f3o"><text>"0%"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/output-order.dmn
+++ b/public/hit-policies/output-order.dmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_OutputOrder" name="OutputOrder" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Warnings" name="Weather Warnings (by severity)">
+    <decisionTable id="DT_OutputOrder" hitPolicy="OUTPUT ORDER">
+      <input id="in_temp" label="Temperature (°C)">
+        <inputExpression id="ie_temp" typeRef="integer"><text>Temp</text></inputExpression>
+      </input>
+      <output id="out_warn" label="Warning" name="Warning" typeRef="string">
+        <outputValues id="ov_warn"><text>"Extreme Heat","Heat"</text></outputValues>
+      </output>
+      <rule id="o1">
+        <inputEntry id="o1i"><text>&gt; 30</text></inputEntry>
+        <outputEntry id="o1o"><text>"Heat"</text></outputEntry>
+      </rule>
+      <rule id="o2">
+        <inputEntry id="o2i"><text>&gt; 35</text></inputEntry>
+        <outputEntry id="o2o"><text>"Extreme Heat"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/priority.dmn
+++ b/public/hit-policies/priority.dmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_Priority" name="Priority" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Risk" name="Application Risk">
+    <decisionTable id="DT_Priority" hitPolicy="PRIORITY">
+      <input id="in_score" label="Credit Score">
+        <inputExpression id="ie_score" typeRef="integer"><text>Score</text></inputExpression>
+      </input>
+      <output id="out_risk" label="Decision" name="Decision" typeRef="string">
+        <outputValues id="ov_risk"><text>"Decline","Review","Approve"</text></outputValues>
+      </output>
+      <rule id="p1">
+        <inputEntry id="p1i"><text>&lt; 700</text></inputEntry>
+        <outputEntry id="p1o"><text>"Review"</text></outputEntry>
+      </rule>
+      <rule id="p2">
+        <inputEntry id="p2i"><text>&lt; 600</text></inputEntry>
+        <outputEntry id="p2o"><text>"Decline"</text></outputEntry>
+      </rule>
+      <rule id="p3">
+        <inputEntry id="p3i"><text>&gt;= 0</text></inputEntry>
+        <outputEntry id="p3o"><text>"Approve"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/rule-order.dmn
+++ b/public/hit-policies/rule-order.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_RuleOrder" name="RuleOrder" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Warnings" name="Weather Warnings">
+    <decisionTable id="DT_RuleOrder" hitPolicy="RULE ORDER">
+      <input id="in_temp" label="Temperature (°C)">
+        <inputExpression id="ie_temp" typeRef="integer"><text>Temp</text></inputExpression>
+      </input>
+      <output id="out_warn" label="Warning" name="Warning" typeRef="string" />
+      <rule id="r1">
+        <inputEntry id="r1i"><text>&gt; 30</text></inputEntry>
+        <outputEntry id="r1o"><text>"Heat"</text></outputEntry>
+      </rule>
+      <rule id="r2">
+        <inputEntry id="r2i"><text>&gt; 35</text></inputEntry>
+        <outputEntry id="r2o"><text>"Extreme Heat"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/public/hit-policies/unique.dmn
+++ b/public/hit-policies/unique.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="Definitions_Unique" name="Unique" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="Decision_Tier" name="Membership Tier">
+    <decisionTable id="DT_Unique" hitPolicy="UNIQUE">
+      <input id="in_spend" label="Yearly Spend (€)">
+        <inputExpression id="ie_spend" typeRef="integer"><text>Spend</text></inputExpression>
+      </input>
+      <output id="out_tier" label="Tier" name="Tier" typeRef="string" />
+      <rule id="u1">
+        <inputEntry id="u1i"><text>&lt; 1000</text></inputEntry>
+        <outputEntry id="u1o"><text>"Bronze"</text></outputEntry>
+      </rule>
+      <rule id="u2">
+        <inputEntry id="u2i"><text>[1000..5000)</text></inputEntry>
+        <outputEntry id="u2o"><text>"Silver"</text></outputEntry>
+      </rule>
+      <rule id="u3">
+        <inputEntry id="u3i"><text>&gt;= 5000</text></inputEntry>
+        <outputEntry id="u3o"><text>"Gold"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/shared/lib/dmnModel.ts
+++ b/shared/lib/dmnModel.ts
@@ -1,0 +1,181 @@
+/**
+ * Parse a DMN decision table into a plain model that can drive a simulation UI
+ * and be evaluated with a FEEL engine — no dmn-js instance required.
+ *
+ * Only the parts a single decision table needs are extracted: its inputs,
+ * outputs, rules (as raw FEEL text) and hit policy. FEEL is never interpreted
+ * here — see `evaluateDecision.ts` for that.
+ */
+
+export type HitPolicy =
+  | 'UNIQUE'
+  | 'FIRST'
+  | 'ANY'
+  | 'PRIORITY'
+  | 'COLLECT'
+  | 'RULE ORDER'
+  | 'OUTPUT ORDER'
+
+export interface DmnInput {
+  id: string
+  /** Human label shown in the form (falls back to the input expression). */
+  label: string
+  /** The FEEL input expression, i.e. the variable name (e.g. `Season`). */
+  expression: string
+  /** DMN typeRef of the input (`string`, `integer`, `boolean`, …). */
+  typeRef: string
+  /** Distinct string literals used in this column — drives a dropdown. */
+  options: string[]
+}
+
+export interface DmnOutput {
+  id: string
+  /** Key used in the result object — output name, else label, else fallback. */
+  name: string
+  label: string
+  typeRef: string
+  /**
+   * Allowed output values in priority order (highest first), from
+   * `<outputValues>`. Drives PRIORITY and OUTPUT ORDER; empty when unset.
+   */
+  priorityValues: string[]
+}
+
+/** COLLECT aggregator (`aggregation` attribute); undefined = plain list. */
+export type Aggregation = 'SUM' | 'MIN' | 'MAX' | 'COUNT'
+
+export interface DmnRule {
+  id: string
+  /** Raw FEEL unary-test text per input column (aligned to `inputs`). */
+  inputEntries: string[]
+  /** Raw FEEL expression text per output column (aligned to `outputs`). */
+  outputEntries: string[]
+}
+
+export interface DecisionModel {
+  decisionId: string
+  decisionName: string
+  hitPolicy: HitPolicy
+  /** COLLECT aggregator, if any (`SUM`/`MIN`/`MAX`/`COUNT`). */
+  aggregation?: Aggregation
+  inputs: DmnInput[]
+  outputs: DmnOutput[]
+  rules: DmnRule[]
+}
+
+/** Split a FEEL `outputValues` list (`"a","b","c"`) into ordered bare values. */
+function parseOutputValues(text: string): string[] {
+  if (!text) return []
+  return text
+    .split(',')
+    .map(part => part.trim().replace(/^"(.*)"$/, '$1'))
+    .filter(part => part.length > 0)
+}
+
+/** Namespace-agnostic lookup — DMN files use a default (prefix-less) namespace. */
+function byLocalName(scope: Element | Document, localName: string): Element[] {
+  return Array.from(scope.getElementsByTagNameNS('*', localName))
+}
+
+function firstByLocalName(scope: Element | Document, localName: string): Element | null {
+  return byLocalName(scope, localName)[0] ?? null
+}
+
+/** Text of the nested `<text>` element (used by input/output entries). */
+function entryText(entry: Element | undefined): string {
+  if (!entry) return ''
+  const text = firstByLocalName(entry, 'text')
+  return (text?.textContent ?? '').trim()
+}
+
+/**
+ * Parse the first decision table (or the one matching `decisionId`) from a DMN
+ * XML string.
+ *
+ * @throws if the XML is malformed or contains no decision table.
+ */
+export function parseDecisionModel(xml: string, decisionId?: string): DecisionModel {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml')
+  if (firstByLocalName(doc, 'parsererror')) {
+    throw new Error('DMN XML could not be parsed')
+  }
+
+  const decisions = byLocalName(doc, 'decision')
+  const decision = decisionId
+    ? decisions.find(d => d.getAttribute('id') === decisionId)
+    : decisions.find(d => firstByLocalName(d, 'decisionTable'))
+  if (!decision) {
+    throw new Error(
+      decisionId
+        ? `No decision with id "${decisionId}" found`
+        : 'No decision with a decision table found',
+    )
+  }
+
+  const table = firstByLocalName(decision, 'decisionTable')
+  if (!table) {
+    throw new Error('Selected decision has no decision table')
+  }
+
+  const hitPolicy = (table.getAttribute('hitPolicy') || 'UNIQUE').toUpperCase() as HitPolicy
+  const aggregationAttr = (table.getAttribute('aggregation') || '').toUpperCase()
+  const aggregation = (['SUM', 'MIN', 'MAX', 'COUNT'] as const).find(a => a === aggregationAttr)
+
+  // Only the columns that belong to *this* table (skip nested inputData vars).
+  const inputEls = byLocalName(table, 'input')
+  const outputEls = byLocalName(table, 'output')
+  const ruleEls = byLocalName(table, 'rule')
+
+  const rules: DmnRule[] = ruleEls.map((rule, ri) => ({
+    id: rule.getAttribute('id') || `rule_${ri}`,
+    inputEntries: byLocalName(rule, 'inputEntry').map(entryText),
+    outputEntries: byLocalName(rule, 'outputEntry').map(entryText),
+  }))
+
+  const inputs: DmnInput[] = inputEls.map((input, ci) => {
+    const expressionEl = firstByLocalName(input, 'inputExpression')
+    const expression = entryText(expressionEl ?? undefined)
+    const label = input.getAttribute('label') || expression || `Input ${ci + 1}`
+    const typeRef = expressionEl?.getAttribute('typeRef') || 'string'
+
+    // Collect the distinct string literals used in this column so the form can
+    // offer a dropdown instead of a free-text field.
+    const options: string[] = []
+    for (const rule of rules) {
+      const match = /^"(.*)"$/.exec(rule.inputEntries[ci] ?? '')
+      if (match && !options.includes(match[1])) options.push(match[1])
+    }
+
+    return { id: input.getAttribute('id') || `input_${ci}`, label, expression, typeRef, options }
+  })
+
+  const outputs: DmnOutput[] = outputEls.map((output, ci) => {
+    const label = output.getAttribute('label') || ''
+    const name = output.getAttribute('name') || label || `Output ${ci + 1}`
+    const priorityValues = parseOutputValues(entryText(firstByLocalName(output, 'outputValues') ?? undefined))
+    return {
+      id: output.getAttribute('id') || `output_${ci}`,
+      name,
+      label: label || name,
+      typeRef: output.getAttribute('typeRef') || 'string',
+      priorityValues,
+    }
+  })
+
+  return {
+    decisionId: decision.getAttribute('id') || '',
+    decisionName: decision.getAttribute('name') || '',
+    hitPolicy,
+    aggregation,
+    inputs,
+    outputs,
+    rules,
+  }
+}
+
+const NUMERIC_TYPES = new Set(['integer', 'long', 'int', 'number', 'double', 'decimal', 'float'])
+
+/** Whether a DMN typeRef should be edited as a number field. */
+export function isNumericType(typeRef: string): boolean {
+  return NUMERIC_TYPES.has((typeRef || '').toLowerCase())
+}

--- a/shared/lib/evaluateDecision.ts
+++ b/shared/lib/evaluateDecision.ts
@@ -1,0 +1,68 @@
+/**
+ * Evaluate a parsed DMN decision table against user-supplied input values.
+ *
+ * This is the orchestrator that wires the pieces together: coerce inputs, run
+ * each rule's FEEL unary tests to find matches (`feel.ts`), evaluate the matched
+ * rules' output expressions, then let the hit policy decide the result
+ * (`hitPolicy.ts`). It is the DMN analogue of BPMN token simulation — DMN is
+ * declarative, so "simulation" means: feed inputs in, see which rule(s) fire.
+ */
+
+import type { DecisionModel } from './dmnModel'
+import { coerceValue, evaluateExpression, evaluateUnaryTest, type RawValue } from './feel'
+import { applyHitPolicy, type HitPolicyResult, type RuleOutput } from './hitPolicy'
+
+export type { RawValue } from './feel'
+export type { AggregationResult } from './hitPolicy'
+
+export interface EvaluationResult extends HitPolicyResult {
+  /** Every rule that matched, in table order — drives row highlighting. */
+  matchedRuleIndices: number[]
+}
+
+/**
+ * Whether an input cell matches a value. An empty cell or a dash always matches
+ * (DMN "any"); a concrete test against a missing value never matches.
+ */
+function inputCellMatches(cellText: string, value: unknown): boolean {
+  const text = (cellText || '').trim()
+  if (text === '' || text === '-') return true
+  if (value === undefined || value === null) return false
+  return evaluateUnaryTest(text, value)
+}
+
+/** Evaluate every output cell of a rule into an object keyed by output name. */
+function ruleOutput(model: DecisionModel, ruleIndex: number, context: Record<string, unknown>): RuleOutput {
+  const rule = model.rules[ruleIndex]
+  const obj: RuleOutput = {}
+  model.outputs.forEach((output, ci) => {
+    const text = (rule.outputEntries[ci] || '').trim()
+    obj[output.name] = text === '' ? null : evaluateExpression(text, context)
+  })
+  return obj
+}
+
+export function evaluateDecision(model: DecisionModel, rawValues: RawValue[]): EvaluationResult {
+  const values = model.inputs.map((input, i) => coerceValue(rawValues[i], input.typeRef))
+
+  // Context for output expressions: bind each input by its FEEL expression and
+  // by its label so literal *or* referencing outputs both resolve.
+  const context: Record<string, unknown> = {}
+  model.inputs.forEach((input, i) => {
+    if (values[i] === undefined) return
+    if (input.expression) context[input.expression] = values[i]
+    if (input.label) context[input.label] = values[i]
+  })
+
+  const matchedRuleIndices: number[] = []
+  model.rules.forEach((rule, ri) => {
+    if (model.inputs.every((_, ci) => inputCellMatches(rule.inputEntries[ci], values[ci]))) {
+      matchedRuleIndices.push(ri)
+    }
+  })
+
+  const outputsByRule: Record<number, RuleOutput> = {}
+  for (const ri of matchedRuleIndices) outputsByRule[ri] = ruleOutput(model, ri, context)
+
+  return { matchedRuleIndices, ...applyHitPolicy(model, matchedRuleIndices, outputsByRule) }
+}

--- a/shared/lib/feel.ts
+++ b/shared/lib/feel.ts
@@ -1,0 +1,49 @@
+/**
+ * Thin adapter around the `feelin` FEEL engine — the single place that imports
+ * `feelin`. Isolates value coercion and the two FEEL operations a decision table
+ * needs (unary tests for input cells, expressions for output cells) so the rest
+ * of the code never touches the engine directly.
+ */
+
+import { unaryTest, evaluate } from 'feelin'
+import { isNumericType } from './dmnModel'
+
+/** A raw form value before it is coerced to its DMN type. */
+export type RawValue = string | number | boolean | null | undefined
+
+/** Coerce a raw form value into the JS type its DMN typeRef implies. */
+export function coerceValue(raw: RawValue, typeRef: string): unknown {
+  if (raw === undefined || raw === null || raw === '') return undefined
+  if (isNumericType(typeRef)) {
+    const n = Number(raw)
+    return Number.isNaN(n) ? undefined : n
+  }
+  if ((typeRef || '').toLowerCase() === 'boolean') {
+    return raw === true || raw === 'true'
+  }
+  return String(raw)
+}
+
+/**
+ * Evaluate a FEEL unary test against a value (bound to `?`).
+ * Returns false on any parse/evaluation error rather than throwing.
+ */
+export function evaluateUnaryTest(text: string, value: unknown): boolean {
+  try {
+    return unaryTest(text, { '?': value }).value === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Evaluate a FEEL expression against a context.
+ * Returns null on any parse/evaluation error rather than throwing.
+ */
+export function evaluateExpression(text: string, context: Record<string, unknown>): unknown {
+  try {
+    return evaluate(text, context).value
+  } catch {
+    return null
+  }
+}

--- a/shared/lib/hitPolicy.ts
+++ b/shared/lib/hitPolicy.ts
@@ -1,0 +1,140 @@
+/**
+ * DMN hit-policy semantics — pure, FEEL-free. Given the rules that matched and
+ * their already-evaluated output objects, decide which rule(s) form the result
+ * and how their outputs are combined.
+ *
+ * No JS/browser DMN engine covers the full policy set (`dmn-eval-js` and forks
+ * are unmaintained and lack PRIORITY, OUTPUT ORDER and COLLECT aggregations), so
+ * this layer is owned here. It sits on top of `feel.ts`, which handles the FEEL
+ * matching; this module never touches the FEEL engine.
+ */
+
+import type { Aggregation, DecisionModel, DmnOutput } from './dmnModel'
+
+/** A single evaluated rule output, keyed by output name. */
+export type RuleOutput = Record<string, unknown>
+
+export interface AggregationResult {
+  fn: Aggregation
+  /** Name of the (single) output the aggregate was computed over. */
+  output: string
+  value: number
+}
+
+export interface HitPolicyResult {
+  /** Rules whose output forms the result after the hit policy is applied. */
+  reportedRuleIndices: number[]
+  /** Output objects for the reported rules (empty when an aggregation applies). */
+  outputs: RuleOutput[]
+  /** Present for COLLECT with an aggregation (SUM/MIN/MAX/COUNT). */
+  aggregation?: AggregationResult
+  /** Set when the policy's constraint is violated (e.g. UNIQUE matched twice). */
+  violation?: string
+}
+
+/** Priority rank of a value within an output's list (lower = higher priority). */
+function priorityRank(value: unknown, output: DmnOutput): number {
+  const list = output.priorityValues
+  if (!list.length) return Number.POSITIVE_INFINITY
+  const idx = list.indexOf(String(value ?? ''))
+  return idx === -1 ? Number.POSITIVE_INFINITY : idx
+}
+
+/**
+ * Compare two matched rules by output priority (ascending = higher priority).
+ * Outputs are ranked in column order; ties fall back to table order for
+ * stability. Used by PRIORITY (take best) and OUTPUT ORDER (sort all).
+ */
+function byPriority(outputsByRule: Record<number, RuleOutput>, outputs: DmnOutput[]) {
+  return (a: number, b: number): number => {
+    for (const output of outputs) {
+      const ra = priorityRank(outputsByRule[a][output.name], output)
+      const rb = priorityRank(outputsByRule[b][output.name], output)
+      if (ra !== rb) return ra - rb
+    }
+    return a - b
+  }
+}
+
+/** Aggregate the matched rules' first output column (COLLECT + SUM/MIN/MAX/COUNT). */
+function aggregate(
+  fn: Aggregation,
+  matched: number[],
+  outputsByRule: Record<number, RuleOutput>,
+  output: DmnOutput | undefined,
+): AggregationResult {
+  const name = output?.name ?? 'result'
+  if (fn === 'COUNT') return { fn, output: name, value: matched.length }
+
+  const numbers = matched
+    .map(ri => Number(outputsByRule[ri][name]))
+    .filter(n => !Number.isNaN(n))
+
+  let value = 0
+  if (fn === 'SUM') value = numbers.reduce((sum, n) => sum + n, 0)
+  else if (fn === 'MIN') value = numbers.length ? Math.min(...numbers) : 0
+  else if (fn === 'MAX') value = numbers.length ? Math.max(...numbers) : 0
+  return { fn, output: name, value }
+}
+
+/**
+ * Apply the model's hit policy to the matched rules.
+ *
+ * @param matchedRuleIndices rules that matched, in table order
+ * @param outputsByRule      evaluated output object per matched rule index
+ */
+export function applyHitPolicy(
+  model: DecisionModel,
+  matchedRuleIndices: number[],
+  outputsByRule: Record<number, RuleOutput>,
+): HitPolicyResult {
+  let reportedRuleIndices = [...matchedRuleIndices]
+  let aggregation: AggregationResult | undefined
+  let violation: string | undefined
+
+  switch (model.hitPolicy) {
+    case 'FIRST':
+      reportedRuleIndices = matchedRuleIndices.slice(0, 1)
+      break
+
+    case 'UNIQUE':
+      if (matchedRuleIndices.length > 1) {
+        violation = `UNIQUE hit policy violated: ${matchedRuleIndices.length} rules matched (expected at most one)`
+      }
+      reportedRuleIndices = matchedRuleIndices.slice(0, 1)
+      break
+
+    case 'ANY': {
+      const distinct = new Set(matchedRuleIndices.map(ri => JSON.stringify(outputsByRule[ri])))
+      if (distinct.size > 1) {
+        violation = 'ANY hit policy violated: matching rules produced different outputs'
+      }
+      // Every matching rule fires and they all agree, so all are equally "the
+      // result" (highlight all) — but ANY yields a single output value.
+      const output = matchedRuleIndices.length ? [outputsByRule[matchedRuleIndices[0]]] : []
+      return { reportedRuleIndices: matchedRuleIndices, outputs: output, violation }
+    }
+
+    case 'PRIORITY':
+      reportedRuleIndices = [...matchedRuleIndices].sort(byPriority(outputsByRule, model.outputs)).slice(0, 1)
+      break
+
+    case 'OUTPUT ORDER':
+      reportedRuleIndices = [...matchedRuleIndices].sort(byPriority(outputsByRule, model.outputs))
+      break
+
+    case 'COLLECT':
+      if (model.aggregation) {
+        aggregation = aggregate(model.aggregation, matchedRuleIndices, outputsByRule, model.outputs[0])
+      }
+      reportedRuleIndices = matchedRuleIndices
+      break
+
+    case 'RULE ORDER':
+    default:
+      reportedRuleIndices = matchedRuleIndices
+  }
+
+  const outputs = aggregation ? [] : reportedRuleIndices.map(ri => outputsByRule[ri])
+  return { reportedRuleIndices, outputs, aggregation, violation }
+}

--- a/tests/components/DmnSimulate.test.ts
+++ b/tests/components/DmnSimulate.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { enableAutoUnmount, mount, flushPromises } from '@vue/test-utils'
+
+enableAutoUnmount(afterEach)
+
+const { mockImportXML, mockOpen, mockGetViews, MockDmnViewer } = vi.hoisted(() => ({
+  mockImportXML: vi.fn(),
+  mockOpen: vi.fn(),
+  mockGetViews: vi.fn(),
+  MockDmnViewer: vi.fn(),
+}))
+
+vi.mock('dmn-js/lib/Viewer', () => ({ default: MockDmnViewer }))
+
+const { slideEnterCallbacks } = vi.hoisted(() => ({ slideEnterCallbacks: [] as Array<() => void> }))
+vi.mock('@slidev/client', () => ({
+  onSlideEnter: vi.fn((cb: () => void) => { slideEnterCallbacks.push(cb) }),
+}))
+
+import DmnSimulate from '../../components/DmnSimulate.vue'
+
+const exampleXml = readFileSync(resolve(process.cwd(), 'public/example.dmn'), 'utf-8')
+const TABLE_VIEW = { type: 'decisionTable', element: { id: 'Decision_Dish' } }
+
+function mockFetch(xml = exampleXml) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(xml) }))
+}
+
+function giveContainerDimensions(wrapper: ReturnType<typeof mount>) {
+  const el = wrapper.find('div.dmn-table-wrapper').element as HTMLDivElement
+  Object.defineProperty(el, 'clientWidth', { value: 800, configurable: true })
+  Object.defineProperty(el, 'clientHeight', { value: 400, configurable: true })
+}
+
+async function waitForRender() {
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await flushPromises()
+}
+
+describe('DmnSimulate.vue', () => {
+  beforeEach(() => {
+    slideEnterCallbacks.length = 0
+    mockImportXML.mockResolvedValue(undefined)
+    mockOpen.mockResolvedValue(undefined)
+    mockGetViews.mockReturnValue([TABLE_VIEW])
+    MockDmnViewer.mockImplementation(function () {
+      return { importXML: mockImportXML, getViews: mockGetViews, open: mockOpen }
+    })
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('shows a loading state initially', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    expect(wrapper.text()).toContain('Loading DMN decision table...')
+  })
+
+  it('derives one input control per decision-table input from the parsed model', async () => {
+    mockFetch()
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    await waitForRender()
+
+    const fields = wrapper.findAll('.sim-field')
+    expect(fields).toHaveLength(2) // Season, Number of Guests
+    // Season is a string column with literal values → dropdown
+    const options = wrapper.find('.sim-field select').findAll('option').map(o => o.text())
+    expect(options).toContain('Fall')
+    expect(options).toContain('Summer')
+    // Guest count is numeric → number input
+    expect(wrapper.find('.sim-field input[type="number"]').exists()).toBe(true)
+  })
+
+  it('keeps Simulate disabled until every input has a value', async () => {
+    mockFetch()
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    await waitForRender()
+
+    const button = wrapper.find('button.sim-run')
+    expect(button.attributes('disabled')).toBeDefined()
+
+    await wrapper.find('.sim-field select').setValue('Fall')
+    expect(button.attributes('disabled')).toBeDefined() // guests still empty
+
+    await wrapper.find('.sim-field input[type="number"]').setValue('8')
+    expect(button.attributes('disabled')).toBeUndefined()
+  })
+
+  it('evaluates the decision and shows the matched output', async () => {
+    mockFetch()
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    await waitForRender()
+
+    await wrapper.find('.sim-field select').setValue('Fall')
+    await wrapper.find('.sim-field input[type="number"]').setValue('8')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    const result = wrapper.find('.sim-result')
+    expect(result.exists()).toBe(true)
+    expect(result.text()).toContain('Spareribs')
+    expect(result.text()).toContain('Rule 1')
+  })
+
+  it('resets inputs and clears the result', async () => {
+    mockFetch()
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    await waitForRender()
+
+    await wrapper.find('.sim-field select').setValue('Fall')
+    await wrapper.find('.sim-field input[type="number"]').setValue('8')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(wrapper.find('.sim-result').exists()).toBe(true)
+
+    await wrapper.find('button.sim-reset').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.sim-result').exists()).toBe(false)
+    expect(wrapper.find('button.sim-run').attributes('disabled')).toBeDefined()
+  })
+
+  it('shows an error when the decision table cannot be found', async () => {
+    mockGetViews.mockReturnValue([{ type: 'drd' }])
+    mockFetch()
+    const wrapper = mount(DmnSimulate, { props: { dmnFilePath: 'example.dmn' } })
+    giveContainerDimensions(wrapper)
+    await waitForRender()
+    expect(wrapper.text()).toContain('Failed to load DMN')
+  })
+})

--- a/tests/composables/useDmn.test.ts
+++ b/tests/composables/useDmn.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useDmn } from '../../composables/useDmn'
+
+describe('useDmn', () => {
+  it('starts in a loading state with no error', () => {
+    const { loading, error } = useDmn()
+    expect(loading.value).toBe(true)
+    expect(error.value).toBeNull()
+  })
+
+  it('fetchDmnXml returns the response text on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('<definitions/>') }))
+    const { fetchDmnXml } = useDmn()
+    await expect(fetchDmnXml('example.dmn')).resolves.toBe('<definitions/>')
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('fetchDmnXml throws with the status on a failed response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+    const { fetchDmnXml } = useDmn()
+    await expect(fetchDmnXml('missing.dmn')).rejects.toThrow(/404/)
+  })
+
+  it('withLoading toggles loading and returns the value on success', async () => {
+    const { loading, error, withLoading } = useDmn()
+    const result = await withLoading(async () => 42)
+    expect(result).toBe(42)
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('withLoading captures the error and returns undefined on failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { loading, error, withLoading } = useDmn()
+    const result = await withLoading(async () => { throw new Error('boom') })
+    expect(result).toBeUndefined()
+    expect(loading.value).toBe(false)
+    expect(error.value).toMatch(/boom/)
+  })
+})

--- a/tests/engines/camunda.test.ts
+++ b/tests/engines/camunda.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the heavy dmn-js / moddle imports so the test stays hermetic and fast —
+// it verifies how camunda.ts *wires* them, not their internals.
+vi.mock('dmn-js-properties-panel', () => ({
+  DmnPropertiesPanelModule: { __id: 'panel' },
+  DmnPropertiesProviderModule: { __id: 'provider' },
+  CamundaPropertiesProviderModule: { __id: 'camunda-provider' },
+}))
+vi.mock('camunda-dmn-moddle/resources/camunda.json', () => ({ default: { name: 'Camunda' } }))
+
+import { camundaEngine } from '../../engines/camunda'
+import {
+  DmnPropertiesPanelModule,
+  DmnPropertiesProviderModule,
+  CamundaPropertiesProviderModule,
+} from 'dmn-js-properties-panel'
+
+describe('camundaEngine', () => {
+  it('bundles the three DMN properties-panel modules', () => {
+    expect(camundaEngine.additionalModules).toEqual([
+      DmnPropertiesPanelModule,
+      DmnPropertiesProviderModule,
+      CamundaPropertiesProviderModule,
+    ])
+  })
+
+  it('registers the camunda moddle extension under the `camunda` namespace', () => {
+    expect(camundaEngine.moddleExtensions).toHaveProperty('camunda')
+    expect((camundaEngine.moddleExtensions.camunda as { name: string }).name).toBe('Camunda')
+  })
+})

--- a/tests/lib/dmnModel.test.ts
+++ b/tests/lib/dmnModel.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parseDecisionModel, isNumericType } from '../../shared/lib/dmnModel'
+
+const exampleXml = readFileSync(resolve(process.cwd(), 'public/example.dmn'), 'utf-8')
+
+describe('parseDecisionModel', () => {
+  it('parses inputs, outputs, rules and hit policy from the example', () => {
+    const model = parseDecisionModel(exampleXml)
+
+    expect(model.decisionName).toBe('Dish')
+    expect(model.hitPolicy).toBe('FIRST')
+    expect(model.inputs.map(i => i.label)).toEqual(['Season', 'Number of Guests'])
+    expect(model.outputs.map(o => o.name)).toEqual(['Dish'])
+    expect(model.rules).toHaveLength(5)
+  })
+
+  it('derives the correct types and dropdown options per input column', () => {
+    const model = parseDecisionModel(exampleXml)
+    const [season, guests] = model.inputs
+
+    expect(season.typeRef).toBe('string')
+    expect(season.options).toEqual(['Fall', 'Winter', 'Spring', 'Summer'])
+    expect(guests.typeRef).toBe('integer')
+    expect(guests.options).toEqual([]) // numeric column → no literal dropdown
+  })
+
+  it('selects a decision by id', () => {
+    const model = parseDecisionModel(exampleXml, 'Decision_Dish')
+    expect(model.decisionId).toBe('Decision_Dish')
+  })
+
+  it('throws on a missing decision id', () => {
+    expect(() => parseDecisionModel(exampleXml, 'Nope')).toThrow(/No decision with id/)
+  })
+
+  it('throws on malformed XML', () => {
+    expect(() => parseDecisionModel('<definitions')).toThrow()
+  })
+
+  it('parses the COLLECT aggregation attribute and output priority values', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="d" name="d">
+        <decision id="Decision_Risk" name="Risk">
+          <decisionTable id="T" hitPolicy="COLLECT" aggregation="SUM">
+            <input id="i"><inputExpression id="ie" typeRef="integer"><text>Score</text></inputExpression></input>
+            <output id="o" label="Points" typeRef="integer">
+              <outputValues><text>"High","Medium","Low"</text></outputValues>
+            </output>
+            <rule id="r1"><inputEntry id="ie1"><text>&gt; 0</text></inputEntry><outputEntry id="oe1"><text>5</text></outputEntry></rule>
+          </decisionTable>
+        </decision>
+      </definitions>`
+    const model = parseDecisionModel(xml)
+    expect(model.hitPolicy).toBe('COLLECT')
+    expect(model.aggregation).toBe('SUM')
+    expect(model.outputs[0].priorityValues).toEqual(['High', 'Medium', 'Low'])
+  })
+
+  it('leaves aggregation undefined and priority values empty when unset', () => {
+    const model = parseDecisionModel(exampleXml)
+    expect(model.aggregation).toBeUndefined()
+    expect(model.outputs[0].priorityValues).toEqual([])
+  })
+})
+
+describe('isNumericType', () => {
+  it('recognises numeric DMN types case-insensitively', () => {
+    expect(isNumericType('integer')).toBe(true)
+    expect(isNumericType('Double')).toBe(true)
+    expect(isNumericType('string')).toBe(false)
+  })
+})

--- a/tests/lib/evaluateDecision.test.ts
+++ b/tests/lib/evaluateDecision.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parseDecisionModel } from '../../shared/lib/dmnModel'
+import { evaluateDecision } from '../../shared/lib/evaluateDecision'
+
+/**
+ * End-to-end tests for the orchestrator: parse → FEEL matching → output
+ * evaluation → hit policy, exercised through real DMN XML. Isolated FEEL and
+ * hit-policy behaviour is covered in feel.test.ts / hitPolicy.test.ts.
+ */
+const exampleXml = readFileSync(resolve(process.cwd(), 'public/example.dmn'), 'utf-8')
+const dish = parseDecisionModel(exampleXml)
+
+describe('evaluateDecision — FIRST decision table (example.dmn)', () => {
+  it('fires the first matching rule and returns its output', () => {
+    const r = evaluateDecision(dish, ['Fall', 8])
+    expect(r.matchedRuleIndices).toEqual([0])
+    expect(r.reportedRuleIndices).toEqual([0])
+    expect(r.outputs).toEqual([{ Dish: 'Spareribs' }])
+  })
+
+  it('evaluates numeric unary tests (<= / >)', () => {
+    expect(evaluateDecision(dish, ['Winter', 8]).outputs).toEqual([{ Dish: 'Roastbeef' }])
+    expect(evaluateDecision(dish, ['Spring', 4]).outputs).toEqual([{ Dish: 'Dry Aged Gourmet Steak' }])
+    expect(evaluateDecision(dish, ['Spring', 5]).outputs).toEqual([{ Dish: 'Stew' }])
+  })
+
+  it('treats an empty input cell as a wildcard match', () => {
+    // Rule 5 (Summer) has an empty guest-count cell — any count matches.
+    const r = evaluateDecision(dish, ['Summer', 999])
+    expect(r.matchedRuleIndices).toEqual([4])
+    expect(r.outputs).toEqual([{ Dish: 'Light Salad and a nice Steak' }])
+  })
+
+  it('reports no match when nothing fires', () => {
+    const r = evaluateDecision(dish, ['Fall', 20])
+    expect(r.matchedRuleIndices).toEqual([])
+    expect(r.outputs).toEqual([])
+  })
+
+  it('does not match a concrete test when the input is missing', () => {
+    expect(evaluateDecision(dish, ['', '']).matchedRuleIndices).toEqual([])
+  })
+})
+
+describe('evaluateDecision — COLLECT with SUM aggregation (end-to-end)', () => {
+  const sumXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="d" name="d">
+      <decision id="Decision_Points" name="Points">
+        <decisionTable id="T" hitPolicy="COLLECT" aggregation="SUM">
+          <input id="i"><inputExpression id="ie" typeRef="integer"><text>Cart</text></inputExpression></input>
+          <output id="o" label="Points" name="Points" typeRef="integer" />
+          <rule id="r1"><inputEntry id="e1"><text>&gt;= 50</text></inputEntry><outputEntry id="oe1"><text>5</text></outputEntry></rule>
+          <rule id="r2"><inputEntry id="e2"><text>&gt;= 100</text></inputEntry><outputEntry id="oe2"><text>10</text></outputEntry></rule>
+          <rule id="r3"><inputEntry id="e3"><text>&gt;= 200</text></inputEntry><outputEntry id="oe3"><text>20</text></outputEntry></rule>
+        </decisionTable>
+      </decision>
+    </definitions>`
+
+  it('matches every applicable rule and aggregates their outputs', () => {
+    const model = parseDecisionModel(sumXml)
+    const r = evaluateDecision(model, [250])
+    expect(r.matchedRuleIndices).toEqual([0, 1, 2])
+    expect(r.aggregation).toEqual({ fn: 'SUM', output: 'Points', value: 35 })
+    expect(r.outputs).toEqual([])
+  })
+})

--- a/tests/lib/feel.test.ts
+++ b/tests/lib/feel.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { coerceValue, evaluateUnaryTest, evaluateExpression } from '../../shared/lib/feel'
+
+describe('coerceValue', () => {
+  it('coerces numeric types to numbers', () => {
+    expect(coerceValue('8', 'integer')).toBe(8)
+    expect(coerceValue('3.5', 'double')).toBe(3.5)
+  })
+
+  it('coerces booleans', () => {
+    expect(coerceValue('true', 'boolean')).toBe(true)
+    expect(coerceValue('false', 'boolean')).toBe(false)
+  })
+
+  it('passes strings through', () => {
+    expect(coerceValue('Fall', 'string')).toBe('Fall')
+  })
+
+  it('returns undefined for empty or non-numeric-in-numeric-column input', () => {
+    expect(coerceValue('', 'integer')).toBeUndefined()
+    expect(coerceValue(null, 'string')).toBeUndefined()
+    expect(coerceValue('abc', 'integer')).toBeUndefined()
+  })
+})
+
+describe('evaluateUnaryTest', () => {
+  it('matches string and numeric unary tests', () => {
+    expect(evaluateUnaryTest('"Fall"', 'Fall')).toBe(true)
+    expect(evaluateUnaryTest('"Fall"', 'Winter')).toBe(false)
+    expect(evaluateUnaryTest('<= 8', 5)).toBe(true)
+    expect(evaluateUnaryTest('<= 8', 9)).toBe(false)
+    expect(evaluateUnaryTest('[1..10]', 5)).toBe(true)
+  })
+
+  it('returns false instead of throwing on invalid FEEL', () => {
+    expect(evaluateUnaryTest('', 5)).toBe(false)
+    expect(evaluateUnaryTest('<<<', 5)).toBe(false)
+  })
+})
+
+describe('evaluateExpression', () => {
+  it('evaluates FEEL literals and context references', () => {
+    expect(evaluateExpression('"Spareribs"', {})).toBe('Spareribs')
+    expect(evaluateExpression('1 + 1', {})).toBe(2)
+    expect(evaluateExpression('Season', { Season: 'Fall' })).toBe('Fall')
+  })
+
+  it('returns null instead of throwing on invalid FEEL', () => {
+    expect(evaluateExpression('@@@', {})).toBeNull()
+  })
+})

--- a/tests/lib/fitDiagram.test.ts
+++ b/tests/lib/fitDiagram.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fitDiagram } from '../../shared/lib/fitDiagram'
+
+/** Build a canvas stub: `viewbox()` reads `view`, `viewbox(obj)` records a set. */
+function makeCanvas(view: unknown) {
+  const setCalls: any[] = []
+  const canvas = {
+    setCalls,
+    viewbox: vi.fn((arg?: any) => {
+      if (arg === undefined) return view
+      setCalls.push(arg)
+      return undefined
+    }),
+  }
+  return canvas
+}
+
+describe('fitDiagram', () => {
+  it('does nothing when the inner or outer box is missing or empty', () => {
+    for (const view of [
+      {},
+      { inner: { x: 0, y: 0, width: 0, height: 10 }, outer: { width: 100, height: 100 } },
+      { inner: { x: 0, y: 0, width: 10, height: 10 }, outer: { width: 0, height: 100 } },
+    ]) {
+      const canvas = makeCanvas(view)
+      fitDiagram(canvas)
+      expect(canvas.setCalls).toHaveLength(0)
+    }
+  })
+
+  it('clamps at native size and centres when fitting would enlarge the diagram', () => {
+    // Small diagram (100×100) in a large canvas (1000×1000) → would scale up, so clamp.
+    const canvas = makeCanvas({
+      inner: { x: 0, y: 0, width: 100, height: 100 },
+      outer: { width: 1000, height: 1000 },
+    })
+    fitDiagram(canvas)
+    // Centre of inner is (50,50); at MAX_SCALE=1 the box is the outer size, centred.
+    expect(canvas.setCalls[0]).toEqual({ x: -450, y: -450, width: 1000, height: 1000 })
+  })
+
+  it('expands the slacker axis to match the canvas aspect ratio', () => {
+    // Wide diagram (2000×1000) in a square canvas → shrink (no clamp) + widen box height.
+    const canvas = makeCanvas({
+      inner: { x: 0, y: 0, width: 2000, height: 1000 },
+      outer: { width: 1000, height: 1000 },
+    })
+    fitDiagram(canvas)
+    // pad = 2000*0.05 = 100 → box 2200×1200 at (-100,-100); height grows to 2200,
+    // re-centred: y -= (2200-1200)/2 = 500.
+    expect(canvas.setCalls[0]).toEqual({ x: -100, y: -600, width: 2200, height: 2200 })
+  })
+})

--- a/tests/lib/hitPolicy.test.ts
+++ b/tests/lib/hitPolicy.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import type { Aggregation, DecisionModel, HitPolicy } from '../../shared/lib/dmnModel'
+import { applyHitPolicy, type RuleOutput } from '../../shared/lib/hitPolicy'
+
+/**
+ * Pure hit-policy tests: `applyHitPolicy` takes already-evaluated outputs, so no
+ * FEEL is involved. Models carry only what the policy reads (hitPolicy,
+ * aggregation, outputs); rules/inputs are irrelevant here.
+ */
+function makeModel(
+  hitPolicy: HitPolicy,
+  opts: { priorityValues?: string[]; aggregation?: Aggregation; outputType?: string } = {},
+): DecisionModel {
+  return {
+    decisionId: 'd',
+    decisionName: 'd',
+    hitPolicy,
+    aggregation: opts.aggregation,
+    inputs: [],
+    rules: [],
+    outputs: [{
+      id: 'o',
+      name: 'Out',
+      label: 'Out',
+      typeRef: opts.outputType ?? 'string',
+      priorityValues: opts.priorityValues ?? [],
+    }],
+  }
+}
+
+/** Build the `outputsByRule` map from a list keyed by rule index. */
+function outputs(...vals: unknown[]): Record<number, RuleOutput> {
+  return Object.fromEntries(vals.map((v, i) => [i, { Out: v }]))
+}
+
+describe('FIRST', () => {
+  it('reports the first matching rule', () => {
+    const r = applyHitPolicy(makeModel('FIRST'), [0, 1], outputs('A', 'B'))
+    expect(r.reportedRuleIndices).toEqual([0])
+    expect(r.outputs).toEqual([{ Out: 'A' }])
+    expect(r.violation).toBeUndefined()
+  })
+})
+
+describe('UNIQUE', () => {
+  it('reports a single clean match', () => {
+    const r = applyHitPolicy(makeModel('UNIQUE'), [1], outputs(undefined, 'B'))
+    expect(r.reportedRuleIndices).toEqual([1])
+    expect(r.violation).toBeUndefined()
+  })
+
+  it('flags a violation when more than one rule matches', () => {
+    const r = applyHitPolicy(makeModel('UNIQUE'), [0, 1], outputs('A', 'B'))
+    expect(r.violation).toMatch(/UNIQUE hit policy violated/)
+    expect(r.reportedRuleIndices).toEqual([0])
+  })
+})
+
+describe('ANY', () => {
+  it('highlights every matching rule but returns a single output', () => {
+    const r = applyHitPolicy(makeModel('ANY'), [0, 1], outputs('OK', 'OK'))
+    expect(r.reportedRuleIndices).toEqual([0, 1]) // all agreeing rules count
+    expect(r.outputs).toEqual([{ Out: 'OK' }]) // ...but ANY yields one value
+    expect(r.violation).toBeUndefined()
+  })
+
+  it('flags a violation when matching rules disagree', () => {
+    const r = applyHitPolicy(makeModel('ANY'), [0, 1], outputs('OK', 'NO'))
+    expect(r.violation).toMatch(/ANY hit policy violated/)
+  })
+})
+
+describe('PRIORITY', () => {
+  it('picks the highest-priority output among matches', () => {
+    const model = makeModel('PRIORITY', { priorityValues: ['High', 'Medium', 'Low'] })
+    const r = applyHitPolicy(model, [0, 1], outputs('Low', 'High'))
+    expect(r.reportedRuleIndices).toEqual([1])
+    expect(r.outputs).toEqual([{ Out: 'High' }])
+  })
+})
+
+describe('OUTPUT ORDER', () => {
+  it('lists all matches sorted by output priority', () => {
+    const model = makeModel('OUTPUT ORDER', { priorityValues: ['High', 'Medium', 'Low'] })
+    const r = applyHitPolicy(model, [0, 1], outputs('Low', 'High'))
+    expect(r.reportedRuleIndices).toEqual([1, 0])
+    expect(r.outputs).toEqual([{ Out: 'High' }, { Out: 'Low' }])
+  })
+})
+
+describe('RULE ORDER', () => {
+  it('lists all matches in table order', () => {
+    const r = applyHitPolicy(makeModel('RULE ORDER'), [0, 1], outputs('A', 'B'))
+    expect(r.outputs).toEqual([{ Out: 'A' }, { Out: 'B' }])
+  })
+})
+
+describe('COLLECT', () => {
+  it('collects all matching outputs as a list when unaggregated', () => {
+    const r = applyHitPolicy(makeModel('COLLECT'), [0, 1], outputs('A', 'B'))
+    expect(r.outputs).toEqual([{ Out: 'A' }, { Out: 'B' }])
+    expect(r.aggregation).toBeUndefined()
+  })
+
+  it('SUM aggregates the matched output values', () => {
+    const model = makeModel('COLLECT', { aggregation: 'SUM', outputType: 'integer' })
+    const r = applyHitPolicy(model, [0, 1], outputs(5, 10))
+    expect(r.aggregation).toEqual({ fn: 'SUM', output: 'Out', value: 15 })
+    expect(r.outputs).toEqual([])
+  })
+
+  it('MIN / MAX / COUNT aggregate correctly', () => {
+    const min = applyHitPolicy(makeModel('COLLECT', { aggregation: 'MIN', outputType: 'integer' }), [0, 1], outputs(5, 10))
+    const max = applyHitPolicy(makeModel('COLLECT', { aggregation: 'MAX', outputType: 'integer' }), [0, 1], outputs(5, 10))
+    const count = applyHitPolicy(makeModel('COLLECT', { aggregation: 'COUNT' }), [0, 1], outputs(5, 10))
+    expect(min.aggregation?.value).toBe(5)
+    expect(max.aggregation?.value).toBe(10)
+    expect(count.aggregation?.value).toBe(2)
+  })
+})
+
+describe('no match', () => {
+  it('returns empty results for every policy', () => {
+    for (const policy of ['FIRST', 'UNIQUE', 'COLLECT', 'RULE ORDER', 'PRIORITY'] as HitPolicy[]) {
+      const r = applyHitPolicy(makeModel(policy), [], {})
+      expect(r.reportedRuleIndices).toEqual([])
+      expect(r.outputs).toEqual([])
+    }
+  })
+})

--- a/tests/ui/ToolbarButton.test.ts
+++ b/tests/ui/ToolbarButton.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ToolbarButton from '../../shared/ui/ToolbarButton.vue'
+
+describe('ToolbarButton.vue', () => {
+  it('renders the label and sets the title', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Edit diagram', label: 'Edit' } })
+    expect(wrapper.text()).toContain('Edit')
+    expect(wrapper.find('button').attributes('title')).toBe('Edit diagram')
+  })
+
+  it('omits the label span when no label is given', () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Close' } })
+    expect(wrapper.find('span').exists()).toBe(false)
+  })
+
+  it('emits click with the native event', async () => {
+    const wrapper = mount(ToolbarButton, { props: { title: 'Save' } })
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('click')).toHaveLength(1)
+    expect(wrapper.emitted('click')![0][0]).toBeInstanceOf(MouseEvent)
+  })
+
+  it('renders the icon slot', () => {
+    const wrapper = mount(ToolbarButton, {
+      props: { title: 'Edit' },
+      slots: { icon: '<svg class="my-icon" />' },
+    })
+    expect(wrapper.find('svg.my-icon').exists()).toBe(true)
+  })
+
+  it('applies absolute positioning only when a position is provided', () => {
+    const plain = mount(ToolbarButton, { props: { title: 'x' } })
+    expect(plain.find('button').attributes('style')).not.toContain('position: absolute')
+
+    const positioned = mount(ToolbarButton, { props: { title: 'x', position: { top: '10px', right: '5px' } } })
+    const style = positioned.find('button').attributes('style') ?? ''
+    expect(style).toContain('position: absolute')
+    expect(style).toContain('top: 10px')
+    expect(style).toContain('right: 5px')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       'dmn-js/lib/Viewer',
       'dmn-js/lib/Modeler',
       'dmn-js-properties-panel',
+      'feelin',
     ],
   },
 })


### PR DESCRIPTION
## What

Adds `DmnSimulate.vue` — the DMN analogue of BPMN token simulation. It renders a decision table with an input form, evaluates it live with the [feelin](https://github.com/nikku/feelin) FEEL engine, and highlights the matching rule(s) with the resulting output.

Closes #53

## Highlights

- **Full DMN hit-policy set:** UNIQUE, ANY, PRIORITY, FIRST, COLLECT (incl. `SUM`/`MIN`/`MAX`/`COUNT` aggregation), RULE ORDER, OUTPUT ORDER. No maintained JS/browser DMN engine covers this set (`dmn-eval-js` and forks are unmaintained since 2022 and lack PRIORITY/OUTPUT ORDER/aggregation), so the thin table-orchestration layer is owned here on top of `feelin`.
- **SRP `shared/lib` split**, each with a 1:1 unit test:
  - `dmnModel.ts` — DMN XML → model (parsing)
  - `feel.ts` — `feelin` adapter (the only place importing `feelin`)
  - `hitPolicy.ts` — pure hit-policy semantics
  - `evaluateDecision.ts` — orchestrator
- **UX:** input form derived from the parsed model (dropdowns for string columns), Simulate disabled until all inputs are filled, reported rule(s) highlighted strongly while policy-dropped candidates are faint, aggregate/list/violation results, and the matched row auto-scrolled into view.
- **Docs + demo:** one `example.md` slide per hit policy (`public/hit-policies/*.dmn`); README/CLAUDE updated.

## Testing

- `npm test` — 85 tests across 12 files (1:1 source↔test mapping, incl. new tests for previously-untested `useDmn`, `camunda`, `fitDiagram`, `ToolbarButton`)
- `npm run lint:deps` — no layer/cycle violations
- `npm run build` — green
- Every hit policy driven end-to-end in a headless browser against the demo slides