### PR TITLE
fix: scale decision-table body font with the fontSize prop

### DIFF
--- a/components/DmnSimulate.vue
+++ b/components/DmnSimulate.vue
@@ -465,11 +465,34 @@ onSlideEnter(async () => {
 }
 
 .dmn-simulate .dmn-table-wrapper .dmn-decision-table-container .decision-table-name {
-  font-size: calc(var(--dmn-table-font-size, 12px) * 1.5) !important;
+  font-size: calc(var(--dmn-table-font-size, 12px) * 1.25) !important;
 }
 
+/* Scale the header text with the variable too (mirrors DmnTable). dmn-js pins
+   these to fixed px, so without this they would stay huge once the body shrinks.
+   The `margin` on the labels is fixed px as well, so express it in `em` to keep
+   the header row height proportional to the font. */
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .input-label,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .input-expression,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .output-label,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .output-name {
+  font-size: calc(var(--dmn-table-font-size, 12px) * 1) !important;
+  margin: 1em 0.4em !important;
+}
+
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .clause,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .input-variable,
+.dmn-simulate .dmn-table-wrapper .dmn-decision-table-container thead .output-variable {
+  font-size: calc(var(--dmn-table-font-size, 12px) * 0.85) !important;
+}
+
+/* dmn-js pins the table body to `.tjs-container { font-size: 21px }`, so the rule
+   cells inherit that fixed size and ignore the `font-size` set on the container
+   above. Re-point it at the variable so the cell content — and therefore the row
+   height — scales with `fontSize`. */
 .dmn-simulate .dmn-table-wrapper .tjs-container {
   width: 100% !important;
+  font-size: var(--dmn-table-font-size, 12px) !important;
 }
 
 .dmn-simulate .dmn-table-wrapper .tjs-table-container {

--- a/components/DmnTable.vue
+++ b/components/DmnTable.vue
@@ -159,9 +159,13 @@ onSlideEnter(async () => {
   font-size: calc(var(--dmn-table-font-size, 12px) * 0.85) !important;
 }
 
-/* Force table to fill container width, no x-scroll */
+/* Force table to fill container width, no x-scroll. Also re-point the body font
+   size at the variable: dmn-js pins `.tjs-container` to a fixed 21px, so the rule
+   cells would otherwise ignore the `font-size` set on the container above and the
+   rows would never shrink. */
 .dmn-table-wrapper .tjs-container {
   width: 100% !important;
+  font-size: var(--dmn-table-font-size, 12px) !important;
 }
 
 .dmn-table-wrapper .tjs-table-container {

--- a/example.md
+++ b/example.md
@@ -44,7 +44,7 @@ The `DmnModeler` component embeds an editable diagram – hit **Edit** and the D
 
 The `DmnSimulate` component makes a table a **live decision** – pick the inputs, hit **Simulate**, the matching rule lights up. DMN's answer to BPMN token simulation: feed inputs in, watch the rule fire.
 
-<DmnSimulate dmnFilePath="./example.dmn" height="305px" fontSize="10px"></DmnSimulate>
+<DmnSimulate dmnFilePath="./example.dmn" height="305px" fontSize="9px"></DmnSimulate>
 
 ---
 


### PR DESCRIPTION
## Why

Setting `fontSize` on `DmnTable`/`DmnSimulate` shrank the wrapper and headers but not the table body — cell content and row heights stayed large, so small `fontSize` values had almost no effect.

## What

- dmn-js pins the rule/cell container to a fixed `.tjs-container { font-size: 21px }`, overriding the `font-size` set on the outer container. Re-point `.tjs-container` at the `--dmn-table-font-size` variable in both components so the body text — and therefore row height — scales with the prop.
- Add matching header/label scaling (and proportional `em` margins) to `DmnSimulate`, which previously left the header text at dmn-js's fixed sizes.
- Tune the demo slide to `fontSize="9px"` to show the effect.
